### PR TITLE
Model case refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,8 @@ foreach(p LIB INCLUDE CMAKE)
 endforeach()
 
 # Check that the specified compiler has C++11 support
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(-std=c++11)
-else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
-endif()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Include all directories which contain needed header files
 include_directories("${PROJECT_SOURCE_DIR}")

--- a/include/NEST.hh
+++ b/include/NEST.hh
@@ -194,6 +194,13 @@ class NESTcalc {
                   std::vector<double> NuisParam={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.});
   // Called by GetYields in the NR (and related) cases
   virtual YieldResult GetYieldIon(double energy, double density, double dfield, double massNum, double atomNum, vector<double> NuisParam={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.});
+  // Called by GetYields in the ion case
+  virtual YieldResult GetYieldKr83m(double energy, double density, double dfield);
+  // Called by GetYields in the K383m case
+  virtual YieldResult GetYieldBeta(double energy, double density, double dfield);
+  // Called by GetYields in the Beta/Photoelectric case
+  YieldResult YieldResultValidity(YieldResult& res, const double energy, const double Wq_eV);
+  // Confirms and sometimes adjusts YieldResult to make physical sense
   QuantaResult GetQuanta(YieldResult yields, double density, std::vector<double> FreeParam={1.,1.,0.1,0.5,0.07});
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between

--- a/include/NEST.hh
+++ b/include/NEST.hh
@@ -188,11 +188,21 @@ class NESTcalc {
   // the innermost heart of NEST, this provides floating-point average values
   // for photons and electrons per keV. Nuis(ance)Param included for varying the
   // NR Ly & Qy up and down
+  virtual YieldResult GetYieldGamma(double energy, double density, double dfield);
+  // Called by GetYields in the Gamma case
+  virtual YieldResult GetYieldNR(double energy, double density, double dfield, double massNum,
+                  std::vector<double> NuisParam={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.});
+  // Called by GetYields in the NR (and related) cases
+  virtual YieldResult GetYieldIon(double energy, double density, double dfield, double massNum, double atomNum, vector<double> NuisParam={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.});
   QuantaResult GetQuanta(YieldResult yields, double density, std::vector<double> FreeParam={1.,1.,0.1,0.5,0.07});
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between
   // photons and electrons
   // Namely, the recombination fluctuations
+  virtual double RecombOmegaNR(double elecFrac,vector<double> FreeParam/*={1.,1.,0.1,0.5,0.07}*/);
+  //Calculates the Omega parameter governing non-binomial recombination fluctuations for nuclear recoils and ions (Lindhard<1)
+  virtual double RecombOmegaER(double efield, double recombProb);
+  //Calculates the Omega parameter governing non-binomial recombination fluctuations for gammas and betas (Lindhard==1)
   std::vector<double> GetS1(QuantaResult quanta, double truthPos[3],
                             double smearPos[3], double driftSpeed,
                             double dS_mid, INTERACTION_TYPE species,
@@ -261,7 +271,8 @@ class NESTcalc {
   // Linear Energy Transfer in units of MeV*cm^2/gram which when combined with
   // density can provide the dE/dx, as a function of energy in keV. Will be more
   // useful in the future
-  std::vector<double> WorkFunction(double rho);
+  struct Wvalue {double Wq_eV; double alpha;};
+  Wvalue WorkFunction(double rho);
   //the W-value as a func of density in g/cm^3
   VDetector* GetDetector() { return fdetector; }
 };

--- a/testNEST.cpp
+++ b/testNEST.cpp
@@ -211,7 +211,7 @@ int testNEST(VDetector* detector, unsigned long int numEvts, string type,
     return 1;
   }
   if (rho < 1.75) detector->set_inGas(true);
-  double Wq_eV = n.WorkFunction(rho)[0];
+  double Wq_eV = n.WorkFunction(rho).Wq_eV;
   
   // Calculate and print g1, g2 parameters (once per detector)
   vector<double> g2_params = n.CalculateG2(verbosity);


### PR DESCRIPTION
This branch breaks out the different cases in GetYields into their own virtual class methods. This has the advantage of allowing a user to override individual parts of the model without hard editing the NEST code.