### PR TITLE
Bremsstrahlung gamma treatment in G4 integration.

### DIFF
--- a/G4integration/NESTProc.hh
+++ b/G4integration/NESTProc.hh
@@ -18,6 +18,7 @@
 //#include "G4ThermalElectron.hh"
 #include "G4MaterialCutsCouple.hh"
 #include "G4ProductionCuts.hh"
+#include "G4SystemOfUnits.hh"
 #include "NEST.hh"
 
 namespace NEST {
@@ -120,6 +121,14 @@ class NESTProc : public G4VRestDiscreteProcess {
     this->analysisTrigger = _analysisTrigger;
   }
 
+  void SetGamma_break(double _gamma_break) {
+      this->gamma_break = _gamma_break;
+  }
+
+  double GetGamma_break() const {
+      return gamma_break;
+  }
+
  protected:
   // bools for tracking some special particle cases
 
@@ -133,6 +142,7 @@ class NESTProc : public G4VRestDiscreteProcess {
   
   G4double YieldFactor;  // turns scint. on/off
   bool detailed_secondaries=true;
+  double gamma_break = 9*mm; //Gammas will not pass on their lineage (if they have one, e.g. bremsstrahlung) if they are this far from their origin.
   int verbose=0;
   
   std::function<void(std::vector<NEST::Lineage>)> analysisTrigger;


### PR DESCRIPTION
Added Bremsstrahlung gamma lineage break. If a Brem gamma goes far, we stop adding it in to the same NEST calculation and start a new NEST calculation. This is physically motivated: the experiments that measure yields and inform NEST are looking only at single-hit events for that analysis, not events with multiple hits caused by a far-travelling Brem. What is "far"? It's currently set to 9mm, a reasonable multi-hit resolution for some experiments. The value can be changed by the user.

This fixes an old behavior where a high-energy Bremsstrahlung gamma would be added together with the original ER hit to determine yields, even if that Brem travelled so far that there's no physical reason its microphysics should interact with the original hit.