### PR TITLE
Fano breakout

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -62,6 +62,7 @@ NESTProc::NESTProc(const G4String& processName, G4ProcessType type, NESTcalc* cu
 }
 
 
+
 NESTProc::~NESTProc() {}  // destructor needed to avoid linker error
 
 G4Track* NESTProc::MakePhoton(G4ThreeVector xyz, double t) {

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -213,6 +213,7 @@ class NESTcalc {
   //Calculates the Omega parameter governing non-binomial recombination fluctuations for nuclear recoils and ions (Lindhard<1)
   virtual double RecombOmegaER(double efield, double recombProb);
   //Calculates the Omega parameter governing non-binomial recombination fluctuations for gammas and betas (Lindhard==1)
+  virtual double FanoER(double density, double Nq_mean,double efield);
   std::vector<double> GetS1(QuantaResult quanta, double truthPos[3],
                             double smearPos[3], double driftSpeed,
                             double dS_mid, INTERACTION_TYPE species,

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -214,6 +214,7 @@ class NESTcalc {
   virtual double RecombOmegaER(double efield, double recombProb);
   //Calculates the Omega parameter governing non-binomial recombination fluctuations for gammas and betas (Lindhard==1)
   virtual double FanoER(double density, double Nq_mean,double efield);
+  //Fano-factor (and Fano-like additional energy resolution model) for gammas and betas (Lindhard==1)
   std::vector<double> GetS1(QuantaResult quanta, double truthPos[3],
                             double smearPos[3], double driftSpeed,
                             double dS_mid, INTERACTION_TYPE species,

--- a/include/NEST/testNEST.hh
+++ b/include/NEST/testNEST.hh
@@ -14,4 +14,6 @@ int testNEST(VDetector* detector, unsigned long int numEvts, string type,
              double fPos, int seed, bool no_seed);
 
 
+
 #endif
+

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -139,6 +139,21 @@ double NESTcalc::RecombOmegaER(double efield, double recombProb){
   return omega;
 }
 
+double NESTcalc::FanoER(double density, double Nq_mean,double efield)
+{
+  double Fano = 0.12707 - 0.029623 * density -  // Fano factor is  << 1
+           0.0057042 *
+               pow(density,
+                   2.) +  //~0.1 for GXe w/ formula from Bolotnikov et al. 1995
+           0.0015957 *
+               pow(density,
+                   3.);  // to get it to be ~0.03 for LXe (E Dahl Ph.D. thesis)
+    if (!fdetector->get_inGas())
+      Fano += 0.0015 * sqrt(Nq_mean) * pow(efield, 0.5);
+  return Fano;
+}
+
+
 QuantaResult NESTcalc::GetQuanta(YieldResult yields, double density,
 				 vector<double> FreeParam/*={1.,1.,0.1,0.5,0.07}*/) {
   QuantaResult result;
@@ -171,15 +186,7 @@ QuantaResult NESTcalc::GetQuanta(YieldResult yields, double density,
   }
 
   if (yields.Lindhard == 1.) {
-    double Fano = 0.12707 - 0.029623 * density -  // Fano factor is  << 1
-           0.0057042 *
-               pow(density,
-                   2.) +  //~0.1 for GXe w/ formula from Bolotnikov et al. 1995
-           0.0015957 *
-               pow(density,
-                   3.);  // to get it to be ~0.03 for LXe (E Dahl Ph.D. thesis)
-    if (!fdetector->get_inGas())
-      Fano += 0.0015 * sqrt(Nq_mean) * pow(yields.ElectricField, 0.5);
+    double Fano = FanoER(density,Nq_mean,yields.ElectricField);
     Nq_actual = int(floor(
         RandomGen::rndm()->rand_gauss(Nq_mean, sqrt(Fano * Nq_mean)) + 0.5));
     if (Nq_actual < 0 || Nq_mean == 0.) Nq_actual = 0;


### PR DESCRIPTION
Breaking out the ER fano factor so it can be customized by experiments.

This is motivated by the existing calculation producing a relatively large inherent resolution at 2.54 MeV of ~0.7%: 
`Fano += 0.0015 * sqrt(Nq_mean) * pow(efield, 0.5);`

That value doesn't seem compatible with the Xenon1T recently reported energy resolution of 0.8% (total, including collection, electronics, etc.). While NEST considers an official update to this inherent resolution, experiments can use the model customization features to match their own best guess of the inherent resolution.