### PR TITLE
Clarification to comments

### DIFF
--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -161,14 +161,14 @@ class NESTcalc {
   long BinomFluct(long, double);
   
   static const std::vector<double> default_NuisParam; /* = {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
-  static const std::vector<double> default_FreeParam; /* = {1.,1.,0.1,0.5,0.07} */
+  static const std::vector<double> default_FreeParam; /* = {1.,1.,0.1,0.5,0.19} */
   // basic binomial fluctuation, which switches to Gaussian for large numbers of
   // quanta, this is called repeatedly, and built upon to produce greater,
   // non-binomial fluctuations
   NESTresult FullCalculation(INTERACTION_TYPE species, double energy,
                              double density, double dfield, double A, double Z,
                              std::vector<double> NuisParam = default_NuisParam, /* = {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
-			     std::vector<double> FreeParam = default_FreeParam, /* = {1.,1.,0.1,0.5,0.07} */
+			     std::vector<double> FreeParam = default_FreeParam, /* = {1.,1.,0.1,0.5,0.19} */
                              bool do_times = true);
   // the so-called full NEST calculation puts together all the individual
   // functions/calculations below
@@ -204,12 +204,12 @@ class NESTcalc {
   // Called by GetYields in the Beta/Compton/etc.(IC,Auger,EC) Case
   virtual YieldResult YieldResultValidity(YieldResult& res, const double energy, const double Wq_eV);
   // Confirms and sometimes adjusts YieldResult to make physical sense
-  virtual QuantaResult GetQuanta(YieldResult yields, double density, std::vector<double> FreeParam={1.,1.,0.1,0.5,0.07});
+  virtual QuantaResult GetQuanta(YieldResult yields, double density, std::vector<double> FreeParam={1.,1.,0.1,0.5,0.19});
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between
   // photons and electrons
   // Namely, the recombination fluctuations
-  virtual double RecombOmegaNR(double elecFrac,vector<double> FreeParam/*={1.,1.,0.1,0.5,0.07}*/);
+  virtual double RecombOmegaNR(double elecFrac,vector<double> FreeParam/*={1.,1.,0.1,0.5,0.19}*/);
   //Calculates the Omega parameter governing non-binomial recombination fluctuations for nuclear recoils and ions (Lindhard<1)
   virtual double RecombOmegaER(double efield, double elecFrac);
   //Calculates the Omega parameter governing non-binomial recombination fluctuations for gammas and betas (Lindhard==1)

--- a/include/NEST/RandomGen.hh
+++ b/include/NEST/RandomGen.hh
@@ -20,6 +20,7 @@ class RandomGen {
   double rand_uniform();
   double rand_gauss(double mean, double sigma);
   double rand_exponential(double half_life);
+  double rand_skewGauss( double xi, double omega, double alpha);
   int poisson_draw(double mean);
   int integer_range(int min, int max);
   vector<double> VonNeumann(double xMin, double xMax, double yMin, double yMax,

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -261,9 +261,14 @@ QuantaResult NESTcalc::GetQuanta(YieldResult yields, double density,
   double omega = yields.Lindhard <1 ? RecombOmegaNR(elecFrac, FreeParam) : RecombOmegaER(yields.ElectricField, elecFrac);
   double Variance =
       recombProb * (1. - recombProb) * Ni + omega * omega * Ni * Ni;
+  double skewness = 2.25;
+
+  double widthCorrection = sqrt( 1. - (2./M_PI) * skewness*skewness/(1. + skewness*skewness));
+  double muCorrection = (sqrt(Variance)/widthCorrection)*(skewness/sqrt(1.+skewness*skewness))*sqrt(2./M_PI);
   Ne = int(floor(
-      RandomGen::rndm()->rand_gauss((1. - recombProb) * Ni, sqrt(Variance)) +
-      0.5));
+       RandomGen::rndm()->rand_skewGauss((1. - recombProb) * Ni - muCorrection, sqrt(Variance) / widthCorrection, skewness) +
+       0.5));
+
   if (Ne < 0) Ne = 0;
   if (Ne > Ni) Ne = Ni;
 

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -8,7 +8,7 @@ using namespace std;
 using namespace NEST;
 
 const std::vector<double> NESTcalc::default_NuisParam = {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.};
-const std::vector<double> NESTcalc::default_FreeParam = {1.,1.,0.1,0.5,0.07};
+const std::vector<double> NESTcalc::default_FreeParam = {1.,1.,0.1,0.5,0.19};
 
 long NESTcalc::BinomFluct(long N0, double prob) {
   double mean = N0 * prob;
@@ -37,7 +37,7 @@ NESTresult NESTcalc::FullCalculation(INTERACTION_TYPE species, double energy,
                                      double density, double dfield, double A,
                                      double Z,
                                      vector<double> NuisParam /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
-				     vector<double> FreeParam /*={1.,1.,0.1,0.5,0.07}*/,
+				     vector<double> FreeParam /*={1.,1.,0.1,0.5,0.19}*/,
                                      bool do_times /*=true*/) {
   NESTresult result;
   result.yields = GetYields(species, energy, density, dfield, A, Z, NuisParam);
@@ -123,7 +123,7 @@ photonstream NESTcalc::GetPhotonTimes(INTERACTION_TYPE species,
   return return_photons;
 }
 
-double NESTcalc::RecombOmegaNR(double elecFrac,vector<double> FreeParam/*={1.,1.,0.1,0.5,0.07}*/)
+double NESTcalc::RecombOmegaNR(double elecFrac,vector<double> FreeParam/*={1.,1.,0.1,0.5,0.19}*/)
 {
   double omega = FreeParam[2]*exp(-0.5*pow(elecFrac-FreeParam[3],2.)/(FreeParam[4]*FreeParam[4]));
   if ( omega < 0. )
@@ -162,7 +162,7 @@ double NESTcalc::FanoER(double density, double Nq_mean,double efield)
 
 
 QuantaResult NESTcalc::GetQuanta(YieldResult yields, double density,
-				 vector<double> FreeParam/*={1.,1.,0.1,0.5,0.07}*/) {
+				 vector<double> FreeParam/*={1.,1.,0.1,0.5,0.019}*/) {
   QuantaResult result;
   bool HighE;
   int Nq_actual, Ne, Nph, Ni, Nex;

--- a/src/RandomGen.cpp
+++ b/src/RandomGen.cpp
@@ -40,6 +40,34 @@ double RandomGen::rand_exponential(double half_life) {
   return log(1 - r) * -1 * half_life / log(2.);
 }
 
+double RandomGen::rand_skewGauss(double xi, double omega, double alpha) { 
+  double delta = alpha/sqrt(1 + alpha*alpha);
+  double gamma1 = 0.5*(4. - M_PI)*( pow(delta*sqrt(2./M_PI), 3.) / pow( 1 - 2.*delta*delta/M_PI, 1.5 ) ); //skewness
+  double muz = delta*sqrt(2./M_PI); double sigz = sqrt(1. - muz*muz);
+  double m_o;
+  if (alpha > 0.){
+    m_o = muz - 0.5*gamma1*sigz - 0.5*exp( -2.*M_PI/alpha );
+  }
+  if (alpha < 0.){ 
+    m_o = muz - 0.5*gamma1*sigz + 0.5*exp( +2.*M_PI/alpha );
+  }
+  double mode = xi + omega*m_o;
+  //the height should be the value of the PDF at the mode
+  double height = exp( -0.5*( pow((mode - xi)/omega, 2.) ) ) / ( sqrt( 2.*M_PI ) * omega ) * erfc( -1.*alpha*(mode - xi)/omega/sqrt(2.) );
+  bool gotValue = false;
+  double minX = xi - 6.*omega; double maxX = xi + 6.*omega;  // +/- 6sigma should be essentially +/- inifinity
+                                                             //  can increase these for even better accuracy, at the cost of speed
+  double testX, testY, testProb;
+  while ( gotValue == false ){
+    testX = minX + ( maxX - minX ) * RandomGen::rndm()->rand_uniform(); 
+    testY = height*RandomGen::rndm()->rand_uniform(); // between 0 and peak height
+    //calculate the value of the skewGauss PDF at the test x-value
+    testProb = exp( -0.5*( pow((testX - xi)/omega, 2.) ) ) / ( sqrt( 2.*M_PI ) * omega ) * erfc( -1.*alpha*(testX - xi)/omega/sqrt(2.) );
+    if ( testProb >= testY ){ gotValue =  true; }
+  }
+  return testX;
+}
+
 int RandomGen::poisson_draw(double mean) {
   std::poisson_distribution<int> distribution(mean);
   return distribution(rng);


### PR DESCRIPTION
Default FreeParam[4] has been changed from 0.07 to 0.19 = 0.07 * sqrt(2) * 2. This is now reflected in the comments and default variable declarations.

Also, a fixed skewness model has been added to recombination fluctuations.