### PR TITLE
Diffusion coefficient access + new high-field diffusion model + Garfield integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(NEST VERSION 2.1.0 LANGUAGES CXX)
 option(G4 "Build integration with Geant4" OFF)
 option(BUILD_ROOT "Build ROOT tools" OFF)
 option(BUILD_EXAMPLES "Build NEST examples" ON)
+option(BUILD_GARFIELD "Build integration with Garfield++" ON)
 
 # enable position independent code so shared libraries can link against 
 # the static version of NEST::Core 
@@ -61,6 +62,10 @@ configure_file(examples/220RnCalib.in 220RnCalib)
 
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)
+endif()
+
+if(BUILD_GARFIELD)
+  add_subdirectory(GarfieldppIntegration)
 endif()
 
 if(G4)

--- a/GarfieldppIntegration/CMakeLists.txt
+++ b/GarfieldppIntegration/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+set(MIN_ROOT_VERSION 6.12)
+
+add_executable(GenerateGasTable GenerateGarfieldGasTableForLiquidNoble.cpp)
+target_link_libraries(GenerateGasTable PUBLIC NEST::Core)
+set(GARFIELD GenerateGasTable)
+
+install(
+    TARGETS ${GARFIELD}        
+    RUNTIME DESTINATION bin
+)
+
+
+
+
+
+
+
+

--- a/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
+++ b/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
@@ -1,0 +1,325 @@
+/////////////////////////////////////////////////////
+//
+//  GenerateGarfieldGasTableForLiquidNoble.cpp
+//
+//  rlinehan@stanford.edu
+//  9/12/2020
+//
+//  This code takes NEST as an input and generates
+//  the tables of electron transport properties 
+//  used by the AvalancheMC code in Garfield.
+//
+/////////////////////////////////////////////////////
+
+//C++ includes
+#include <cstdlib>
+#include <iostream>
+
+//NEST includes
+#include "NEST.hh"
+#include "DetectorExample_XENON10.hh"
+
+//Here we choose a correction factor to turn field into "reduced field." This is something
+//that is necessary for Garfield++, which internally scales by the pressure given to it in
+//the Garfield executable. Since we're dealing with liquid, a "pressure" has less meaning
+//than it does with the typical gas environments handled by Garfield. As a result, the important 
+//thing to remember here is that this correction factor needs to be the SAME as the one that is
+//passed to Garfield as the pressure of the medium.
+//THIS VALUE SHOULD NOT EVER BE CHANGED.
+const double reducedFieldCorrectionFactor = 1350; //torr.
+
+
+
+//--------------------------------------------------------------------------------------------------------//
+//This does the work of parsing the arguments passed into the executable and organizing them for use.
+std::tuple<std::string,int,double,double,bool,double> ParseInput(int argc, char** argv)
+{
+  //Sanity check
+  if( argc != 7 ){
+    std::cout << "----> Input Error! Input format should be: ./GenerateGasTable <Element> <nFieldPoints> <minField_VoltsPerCm> <maxField_VoltsPerCm> <Logarithmic:0or1> <Temperature_K>" << std::endl;
+    std::tuple<std::string,int,double,double,bool,double> failure;
+    return failure;
+  }
+  if( argv[1][0] == 'L' ){
+    std::cout << "----> Input Error? Input format of element should be 'Xe' or 'Ar', not 'LXe' or 'LAr.' Please leave the 'L' out." <<std::endl;
+    std::tuple<std::string,int,double,double,bool,double> failure;
+    return failure;
+  }
+  
+  
+  //Start extracting things
+  std::string medium(argv[1]);
+  int fieldPoints = atoi(argv[2]);
+  double minField = atof(argv[3]);
+  double maxField = atof(argv[4]);
+  int logarithmic = atoi(argv[5]);
+  bool boolLog;
+  double temperature = atof(argv[6]);
+
+  if( logarithmic == 0 ){  boolLog = false; }
+  else{ boolLog = true; }
+  std::tuple<std::string,int,double,double,bool,double> output(medium,fieldPoints,minField,maxField,boolLog,temperature);
+  return output;
+  
+}
+
+
+//--------------------------------------------------------------------------------------------------------//
+//Take the inputs, and generate a list of electric fields at which to pull the diffusion constants, 
+//drift velocity, etc. Right now, we're not doing magnetic fields, because LZ has no use for them.
+//However, a similar function (returning some more complicated object of E fields and strengths/relative
+//orientations of B-fields) would do the trick if B-fields are required by a later user.
+std::vector<double> GenerateFieldListFromInputs(std::tuple<std::string,int,double,double,bool,double> inputArgs)
+{
+  //Output
+  std::vector<double> output;
+  
+  //Get relevant things from the tuple
+  bool isLogarithmic = std::get<4>(inputArgs);
+  double minF = std::get<2>(inputArgs);
+  double maxF = std::get<3>(inputArgs);
+  int numF = std::get<1>(inputArgs);
+  
+  //Case based on whether we're using a logarithmic energy scale
+  if( isLogarithmic ){
+    double logMin = log10(minF);
+    double logMax = log10(maxF);
+    double dLogF = (logMax-logMin)/(numF-1);
+    for( int iF = 0; iF < numF; ++iF ){
+      double logField = logMin+dLogF*iF;
+      double field = pow(10,logField);
+      field /= reducedFieldCorrectionFactor; //See the definition of this correction factor for explanation
+      output.push_back(field);
+    }
+  }
+  else{
+    double dField = (maxF-minF)/(numF-1);
+    for( int iF = 0; iF < numF; ++iF){
+      double field = minF+dField*iF;
+      field /= reducedFieldCorrectionFactor; //See the definition of this correction factor for explanation
+      output.push_back(field);
+    }
+  }
+  
+  return output;
+}
+
+//--------------------------------------------------------------------------------------------------------//
+//Pass header information into the output file
+void PassHeaderInformation(std::ofstream & outFile, std::string element, int nFields)
+{
+  outFile << "*----.----1----.----2----.----3----.----4----.----5----.----6----.----7----.----8----.----9----.---10----.---11----.---12----.---13--" << std::endl;
+  char tempString[200]; //Hopefully not initializing this is okay...
+  sprintf(tempString,"%% Created 07/01/20 at 09.04.28 < none > GAS      \"none                         \"");
+  outFile << tempString << std::endl;
+  outFile << " Version   : 12" << std::endl;
+  outFile << " GASOK bits: TFTFFFFTFFFFFFFFFFFF" << std::endl;
+  outFile << " Identifier: " << element << " 100%, T=293.15 K, p=1.77 atm" << std::endl;
+  outFile << " Clusters  :" << std::endl;                                    
+  sprintf(tempString," Dimension : F        %d         1         1        0        0",nFields);
+  outFile << tempString << std::endl;
+  outFile << " E fields   " << std::endl;
+  outFile << " ";
+}
+
+
+//--------------------------------------------------------------------------------------------------------//
+void PassFieldList(std::ofstream & outFile, std::vector<double> fieldList )
+{
+  //Field list chunk
+  for( int iF = 0; iF < fieldList.size(); ++iF ){
+    double eField = fieldList[iF];
+    if( iF > 0 && iF % 5 == 0 ){
+      outFile << std::endl;
+      outFile << " ";
+    }
+    outFile << eField << " ";
+  }
+  outFile << std::endl;
+  return;
+}
+
+//--------------------------------------------------------------------------------------------------------//
+int PassConstantBody(std::ofstream & outFile, std::string element )
+{
+  outFile << " E-B angles" << std::endl;
+  outFile << " 1.57079633E+00" << std::endl;
+  outFile << " B fields" << std::endl;
+  outFile << " 0.00000000E+00" << std::endl;
+  outFile << " Mixture:" << std::endl;
+
+  //This is a dumb, hack-y way to do things, but for now, when we are only looking at pure Xe or Ar, it's simpler
+  //than trying to use Garfield's mixture codes. But since this code is somewhat modular, one can easily come back and
+  //improve this later if it is so desired.
+  if( element == "Xe" ){
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 1.00000000E+02 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+    outFile << " 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00" << std::endl;
+  }
+  else{
+    std::cout << "----> NEST cannot currently generate the mixture for your element " << element << ". Right now, NEST only supports LXe." << std::endl;
+    return -1;
+  }
+  
+  outFile << " The gas tables follow:" << std::endl;
+  outFile << " ";
+  return 0;
+}
+
+
+//--------------------------------------------------------------------------------------------------------//
+//Will be eliminated when NEST.cpp gets a dedicated function for this.
+double GetLatDiffusionConstant(double field_V_cm)
+{
+  
+  double dfield = field_V_cm;
+  double Diff_Tran = 37.368 * pow(dfield, .093452) *
+    exp(-8.1651e-5 * dfield);  // arXiv:1609.04467 (EXO-200)
+  return Diff_Tran;
+}
+
+//--------------------------------------------------------------------------------------------------------//
+//Will be eliminated when NEST.cpp gets a dedicated function for this. //Should be "diffusion coefficient, btw"
+double GetLongDiffusionConstant(double field_V_cm)
+{
+  double dfield = field_V_cm;
+  double Diff_Long = 345.92 * pow(dfield, -0.47880) *
+    exp(-81.3230 / dfield);  // fit to Aprile & Doke review
+  // paper and to arXiv:1102.2865;
+  return Diff_Long;
+}
+
+
+//--------------------------------------------------------------------------------------------------------//
+//This does the bulk of the work in setting up the transport parameters in the gas table. It draws
+//from NEST's models as a function of field and temperature.
+void PassTransportInfo(std::ofstream & outFile, std::vector<double> fieldList_V_cm, double temperature_K )
+{
+  //Create a NEST detector and construct the NEST class using this object
+  DetectorExample_XENON10* detector = new DetectorExample_XENON10();
+  NEST::NESTcalc n(detector);
+  
+    
+  for( int iF = 0; iF < fieldList_V_cm.size(); ++iF ){
+    double field = fieldList_V_cm[iF]; //Note that this is reduced field, in V/cm/torr
+    double driftVel_CmperUs = n.GetDriftVelocity_Liquid(temperature_K, 1,field*reducedFieldCorrectionFactor)/10.;
+    double DT_cm2_s = n.GetDiffTran_Liquid(field*reducedFieldCorrectionFactor,true);
+    double DL_cm2_s = n.GetDiffLong_Liquid(field*reducedFieldCorrectionFactor,true);
+    
+    std::cout << "field: " << field*reducedFieldCorrectionFactor << ", DL: " << DL_cm2_s << ", DT : " << DT_cm2_s << ", driftVel_CmperUs: " << driftVel_CmperUs << std::endl;
+    
+    //Have to get correct units and weight the DL and DT properly for Garfield. NB: Garfield uses the diffusion CONSTANT
+    //as the input, not the diffusion COEFFICIENT. This is why there's a square root of stuff infolved here.
+    double driftVel_CmperS = driftVel_CmperUs*1e6;
+    double DT_modified = pow(2*DT_cm2_s/driftVel_CmperS,0.5)*pow(reducedFieldCorrectionFactor,0.5); 
+    double DL_modified = pow(2*DL_cm2_s/driftVel_CmperS,0.5)*pow(reducedFieldCorrectionFactor,0.5);
+    
+    std::cout << std::scientific;
+    std::cout << "DT_modified: " << DT_modified << std::endl;
+    std::cout << "DL_modified: " << DL_modified << std::endl;
+    
+    
+    double valueToPrint = 0;
+    for( int iEntry = 0; iEntry < 33; ++iEntry ){
+      if( iEntry == 0 ){
+	valueToPrint = driftVel_CmperUs;
+      }
+      else if( iEntry == 6 ){
+	valueToPrint = DL_modified;
+      }
+      else if( iEntry == 8 ){
+	valueToPrint = DT_modified;
+      }
+      else{
+	valueToPrint = 0;
+      }
+      
+      if( iEntry > 0 && iEntry % 8 == 0 ){
+	outFile << std::endl;
+	outFile << " ";
+      }
+      outFile << valueToPrint << " ";
+    }
+    outFile << std::endl;
+    outFile << " ";
+  }
+  return;
+}
+
+
+//--------------------------------------------------------------------------------------------------------//
+//Footer information. The main thing here is that the PGAS NEEDS to match the correction factor at the
+//top of the page. In principle, it should be fine to just leave them the same for all T, Element combinations.
+//TGas is inconsequential, I believe, and can be left as is.
+void PassFooterInformation(std::ofstream & outFile)
+{
+  outFile << "H Extr:     1    1    1    1    1    1    1    1    1    1    1    1    1" << std::endl;
+  outFile << " L Extr:     0    0    0    0    0    0    0    0    0    0    0    0    0" << std::endl;
+  outFile << " Thresholds:          1         1         1" << std::endl;
+  outFile << " Interp:     2    2    2    2    2    2    2    2    2    2    2    2    2" << std::endl;
+  outFile << " A     = 0.00000000E+00, Z     = 0.00000000E+00, EMPROB= 0.00000000E+00, EPAIR = 0.00000000E+00" << std::endl;
+  outFile << " Ion diffusion:  0.00000000E+00 0.00000000E+00" << std::endl;
+  outFile << " CMEAN = 0.00000000E+00, RHO   = 0.00000000E+00, PGAS  = 1.35000000E+03, TGAS  = 2.93150000E+02" << std::endl;
+  outFile << " CLSTYP    : NOT SET   " << std::endl;
+  outFile << " FCNCLS    :                                                                                 " << std::endl;
+  outFile << " NCLS      :          0 " << std::endl;
+  outFile << " Average   :  0.000000000000000000E+00" << std::endl;
+  outFile << " Heed initialisation done: F " << std::endl;
+  outFile << " SRIM initialisation done: F " << std::endl;
+}
+
+
+//--------------------------------------------------------------------------------------------------------//
+//The main function for outputting the "gas" files for liquid noble electron transport parameters
+int main(int argc, char** argv)
+{
+  //Parse the input
+  std::tuple<std::string,int,double,double,bool,double> inputArgs = ParseInput(argc,argv);
+  
+  //Generate the list of the fields desired
+  std::vector<double> fieldList_V_cm = GenerateFieldListFromInputs(inputArgs);
+
+  for( int iF = 0; iF < fieldList_V_cm.size(); ++iF ){
+    std::cout << "Field: " << fieldList_V_cm[iF]*reducedFieldCorrectionFactor << std::endl;
+  }
+  
+  //Define a file to which we print the "gas" table.
+  std::ofstream outFile;
+  char oFileName[100];
+  sprintf(oFileName,"GasTable_%s_%dK.gas",std::get<0>(inputArgs).c_str(),(int)std::get<5>(inputArgs));
+  outFile.open(oFileName);
+  
+  //Pass the header information into the file
+  PassHeaderInformation(outFile,std::get<0>(inputArgs),std::get<1>(inputArgs));
+  
+  //Pass in the field steps
+  outFile.precision(8);
+  outFile << std::scientific;
+  PassFieldList(outFile,fieldList_V_cm);
+
+  //Pass in the mixture information to be written out
+  if( PassConstantBody(outFile,std::get<0>(inputArgs)) != 0 ){
+    std::cout << "----> Incomplete gas file generated. See warnings to continue." << std::endl;
+    return -1;
+  }
+
+  //Pass in the transport info, using the field list and temperature
+  PassTransportInfo(outFile,fieldList_V_cm,std::get<5>(inputArgs));
+
+  //Pass in the footer information
+  PassFooterInformation(outFile);
+  
+  std::cout << "----> Successful generation of gas file." << std::endl;
+
+}  
+  
+  

--- a/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
+++ b/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
@@ -59,8 +59,7 @@ std::tuple<std::string,int,double,double,bool,double> ParseInput(int argc, char*
   if( logarithmic == 0 ){  boolLog = false; }
   else{ boolLog = true; }
   std::tuple<std::string,int,double,double,bool,double> output(medium,fieldPoints,minField,maxField,boolLog,temperature);
-  return output;
-  
+  return output;  
 }
 
 
@@ -99,8 +98,7 @@ std::vector<double> GenerateFieldListFromInputs(std::tuple<std::string,int,doubl
       field /= reducedFieldCorrectionFactor; //See the definition of this correction factor for explanation
       output.push_back(field);
     }
-  }
-  
+  }  
   return output;
 }
 
@@ -179,8 +177,7 @@ int PassConstantBody(std::ofstream & outFile, std::string element )
 //--------------------------------------------------------------------------------------------------------//
 //Will be eliminated when NEST.cpp gets a dedicated function for this.
 double GetLatDiffusionConstant(double field_V_cm)
-{
-  
+{  
   double dfield = field_V_cm;
   double Diff_Tran = 37.368 * pow(dfield, .093452) *
     exp(-8.1651e-5 * dfield);  // arXiv:1609.04467 (EXO-200)
@@ -215,7 +212,7 @@ void PassTransportInfo(std::ofstream & outFile, std::vector<double> fieldList_V_
     double DT_cm2_s = n.GetDiffTran_Liquid(field*reducedFieldCorrectionFactor,true);
     double DL_cm2_s = n.GetDiffLong_Liquid(field*reducedFieldCorrectionFactor,true);
     
-    std::cout << "field: " << field*reducedFieldCorrectionFactor << ", DL: " << DL_cm2_s << ", DT : " << DT_cm2_s << ", driftVel_CmperUs: " << driftVel_CmperUs << std::endl;
+    //    std::cout << "field: " << field*reducedFieldCorrectionFactor << ", DL: " << DL_cm2_s << ", DT : " << DT_cm2_s << ", driftVel_CmperUs: " << driftVel_CmperUs << std::endl;
     
     //Have to get correct units and weight the DL and DT properly for Garfield. NB: Garfield uses the diffusion CONSTANT
     //as the input, not the diffusion COEFFICIENT. This is why there's a square root of stuff infolved here.
@@ -224,8 +221,8 @@ void PassTransportInfo(std::ofstream & outFile, std::vector<double> fieldList_V_
     double DL_modified = pow(2*DL_cm2_s/driftVel_CmperS,0.5)*pow(reducedFieldCorrectionFactor,0.5);
     
     std::cout << std::scientific;
-    std::cout << "DT_modified: " << DT_modified << std::endl;
-    std::cout << "DL_modified: " << DL_modified << std::endl;
+    //    std::cout << "DT_modified: " << DT_modified << std::endl;
+    //std::cout << "DL_modified: " << DL_modified << std::endl;
     
     
     double valueToPrint = 0;
@@ -319,7 +316,4 @@ int main(int argc, char** argv)
   PassFooterInformation(outFile);
   
   std::cout << "----> Successful generation of gas file." << std::endl;
-
-}  
-  
-  
+}

--- a/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
+++ b/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
@@ -14,6 +14,9 @@
 //C++ includes
 #include <cstdlib>
 #include <iostream>
+#include <tuple>
+#include <vector>
+#include <map>
 
 //NEST includes
 #include "NEST.hh"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Noble Element Simulation Technique (nest) is used to simulate noble-element ener
 10. [ Citation ](#citation)
 11. [ License ](#license)
 12. [ Python ](#python)
+13. [ Garfield++ Integration ](#garfield)
 
 
 <a name="get"></a>
@@ -608,3 +609,21 @@ pip install nestpy
 ```
 
 For more information, please see [the bindings project](https://github.com/NESTCollaboration/nestpy).
+
+
+
+
+<a name="garfield"></a>
+## Garfield++ Integration
+
+NEST can produce tables of transport parameters for liquid xenon for use with the Garfield++ package. These tables currently only contain the drift velocity and lateral/longitudinal diffusion information as a function of electric field. They can be used as .gas files in Garfield++ for use with the AvalancheMC process, and are intended to allow a user to make Garfield drift electrons through a "gas" that has the same transport properties as LXe. 
+
+The script GenerateGarfieldGasTableForLiquidNoble.cpp (and its executable GenerateGasTable) will take inputs and produce a gas file for use with Garfield. To execute the script, build NEST, then execute the command
+
+`./GarfieldppIntegration/GenerateGasTable Xe <nFieldPoints> <minField_VperCm> <maxField_VperCm> <Logarithmic:0or1> <Temperature_K>`
+
+from the build directory. Generating tables for additional noble elements is not currently supported, but may be added in the future under popular demand.
+
+Another note: for this to work, the temperature you use in your garfield .cpp file must be 293K, and the pressure must be 1350 torr. This gas file generation assumes these numbers and corrects for them so that the transport coefficients end up correct when the table is passed into Garfield++. If you use anything other than 1350 torr, your transport properties (diffusion, drift velocity, etc.) will be wrong!!!
+
+For more information, contact Ryan Linehan (rlinehan@stanford.edu)

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -304,8 +304,7 @@ class NESTcalc {
   //Read in the Boyle model data for DT
   const std::vector<std::pair<double,double> > GetBoyleModelDT();
   //Read in the Boyle model data for DL
-  const std::vector<std::pair<double,double> > GetBoyleModelDL();
-  
+  const std::vector<std::pair<double,double> > GetBoyleModelDL();  
 };
 }
 

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -293,6 +293,19 @@ class NESTcalc {
   //calculate exciton/ion 
   VDetector* GetDetector() { return fdetector; }
   void SetDetector(VDetector* detector) { fdetector = detector; }  
+
+
+  //Access the diffusion coefficient for transverse diffusion in liquid
+  double GetDiffTran_Liquid(double dfield, bool highFieldModel=false);
+  //Access the diffusion coefficient for longitudinal diffusion in liquid
+  double GetDiffLong_Liquid(double dfield, bool highFieldModel=false);
+  //Function helpful for interpolation of the new diffusion coefficient model (Boyle)
+  double interpolateFunction(const std::vector<std::pair<double,double> > func, double x, bool isLogLog );
+  //Read in the Boyle model data for DT
+  const std::vector<std::pair<double,double> > GetBoyleModelDT();
+  //Read in the Boyle model data for DL
+  const std::vector<std::pair<double,double> > GetBoyleModelDL();
+  
 };
 }
 

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -1867,7 +1867,6 @@ const std::vector<std::pair<double,double> > NESTcalc::GetBoyleModelDT()
     output.push_back(thePair);
   }
   return output;
-
 }
 
 
@@ -1908,8 +1907,5 @@ const std::vector<std::pair<double,double> > NESTcalc::GetBoyleModelDL()
     output.push_back(thePair);
   }
   return output;
-
-
-
 }
 

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -1055,12 +1055,9 @@ vector<double> NESTcalc::GetS2(int Ne, double truthPosX, double truthPosY, doubl
       stopPoint = Nee;
     electronstream.resize(stopPoint, dt);
     double elecTravT = 0., DL, DL_time, DT, phi, sigX, sigY, newX, newY;
-    double Diff_Tran = 37.368 * pow(dfield, .093452) *
-                       exp(-8.1651e-5 * dfield);  // arXiv:1609.04467 (EXO-200)
-    double Diff_Long = 345.92 * pow(dfield, -0.47880) *
-                       exp(-81.3230 / dfield);  // fit to Aprile & Doke review
-                                                // paper and to arXiv:1102.2865;
-                                                // plus, LUX Run02+03
+    double Diff_Tran = GetDiffTran_Liquid(dfield,false);
+    double Diff_Long = GetDiffLong_Liquid(dfield,false);
+
     // a good rule of thumb but only for liquids, as gas kind of opposite:
     // Diff_Long ~ 0.15 * Diff_Tran, as it is in LAr, at least as field goes to
     // infinity
@@ -1740,3 +1737,179 @@ double NESTcalc::NexONi(double energy, double density)
   double alpha = wvalue.alpha;
   return alpha * erf(0.05 * energy);
 }
+
+//This function returns the transverse diffusion coefficient in liquid. It allows a user
+//to select whether they use the canonical NEST model, or a model modified to accommodate higher
+//field values (from Boyle et al., 2016, arXiv:1603.04157v1)
+double NESTcalc::GetDiffTran_Liquid(double dfield, bool highFieldModel)
+{
+  double output;
+
+  //Use the standard NEST parametrization
+  if( !highFieldModel ){
+    output = 37.368 * pow(dfield, .093452) *
+      exp(-8.1651e-5 * dfield);  // arXiv:1609.04467 (EXO-200)
+  }
+  //Use the Boyle model, which is drastically different at high (>5kV/cm) fields. Note here that
+  //the Boyle model is only at one temperature
+  //First double in pair is field, second is DT
+  else{
+    const std::vector<std::pair<double,double> > BoyleModelDT = GetBoyleModelDT();
+    output = interpolateFunction(BoyleModelDT,dfield,true);
+    if( output == 0 ) cerr << "Looks like your desired drift field, " << dfield << ", may be either too low or too high to interpolate a DT. Returning DT=0.\n";
+  }
+  return output;
+}
+
+
+//This function returns the longitudinal diffusion coefficient in liquid. It allows a user
+//to select whether they use the canonical NEST model, or a model modified to accommodate higher
+//field values (from Boyle et al., 2016, arXiv:1603.04157v1)
+double NESTcalc::GetDiffLong_Liquid(double dfield, bool highFieldModel)
+{
+  double output;
+
+  //Use the standard NEST parametrization
+  if( !highFieldModel ){
+    output = 345.92 * pow(dfield, -0.47880) *
+      exp(-81.3230 / dfield);  // fit to Aprile & Doke review
+    // paper and to arXiv:1102.2865;
+    // plus, LUX Run02+03
+  }
+  //Use the Boyle model, which is drastically different at high (>5kV/cm) fields. Note here that
+  //the Boyle model is only at one temperature.  
+  //First double in pair is field, second is DL
+  else{
+    const std::vector<std::pair<double,double> > BoyleModelDL = GetBoyleModelDL();
+    output = interpolateFunction(BoyleModelDL,dfield,true);
+    if( output == 0 ) cerr << "Looks like your desired drift field may be either too low or too high to interpolate a DL Returning DL=0.\n";
+  }
+  return output;
+}
+
+
+//Simple function for interpolating
+double NESTcalc::interpolateFunction(const std::vector<std::pair<double,double> > func, double x, bool isLogLog )
+{
+  //Linear interpolation
+  if( !isLogLog ){
+    double y_desired = 0;
+    for( int iP = 0; iP < func.size()-1; ++iP ){
+      double x1 = func[iP].first;
+      double x2 = func[iP+1].first;
+      if( x1 < x && x2 >= x ){
+	double y1 = func[iP].second;
+	double y2 = func[iP+1].second;
+	double slope = (y2-y1)/(x2-x1);
+	y_desired = y1+(slope*(x-x1));
+	break;
+      }
+    }
+    return y_desired;
+  }
+
+  //Linear interpolation on a log-log scale (more accurate at high fields, where points are far apart on a linear scale)
+  else{
+    double y_desired = 0;
+    for( int iP = 0; iP < func.size()-1; ++iP ){
+      double logx1 = log10(func[iP].first);
+      double logx2 = log10(func[iP+1].first);
+      if( logx1 < log10(x) && logx2 > log10(x) ){
+	double logy1 = log10(func[iP].second);
+	double logy2 = log10(func[iP+1].second);
+	double slope = (logy2-logy1)/(logx2-logx1);
+	double logy_desired = logy1 + slope*(log10(x)-logx1);
+	y_desired = pow(10,logy_desired);
+	break;
+      }
+    }
+    return y_desired;
+  }
+}
+
+    
+
+
+//Organized nicely to just input the Boyle Model's curve data. Using vectors and pairs so
+//all of the size accounting is done nicely downstream without having to pass container
+//sizes around.
+const std::vector<std::pair<double,double> > NESTcalc::GetBoyleModelDT()
+{
+  std::vector<std::pair<double,double> > output;
+  const int nPts = 25;
+  double modelDT[nPts][2] = {{14.6236, 24.674},
+			     {24.5646, 26.4954},
+			     {36.675, 29.2043},
+			     {53.4802, 32.6845},
+			     {74.3939, 37.9944},
+			     {111.071, 45.3424},
+			     {173.835, 58.2226},
+			     {306.106, 74.6236},
+			     {467.921, 89.2124},
+			     {749.809, 96.9913},
+			     {1093.38, 98.4549},
+			     {1711.25, 97.3852},
+			     {2615.85, 92.5493},
+			     {3998.65, 85.4419},
+			     {6258.24, 78.2405},
+			     {9794.71, 67.7294},
+			     {16453.1, 58.544},
+			     {27637.8, 50.3599},
+			     {38445.7, 48.5424},
+			     {49828.3, 43.4695},
+			     {70967.5, 36.8038},
+			     {98719.8, 32.7631},
+			     {127948, 29.5377},
+			     {169785, 27.4412},
+			     {220053, 27.9686} };  
+  for( int iP = 0; iP < nPts; ++iP ){
+    std::pair<double,double> thePair(modelDT[iP][0],modelDT[iP][1]);
+    output.push_back(thePair);
+  }
+  return output;
+
+}
+
+
+//Organized nicely to just input the Boyle Model's curve data. Using vectors and pairs so
+//all of the size accounting is done nicely downstream without having to pass container
+//sizes around. Returns cm^2/s
+const std::vector<std::pair<double,double> > NESTcalc::GetBoyleModelDL()
+{
+  std::vector<std::pair<double,double> > output;
+  const int nPts = 25;
+  double modelDL[nPts][2] = {{14.6236, 22.2977},
+			     {24.5646, 22.4238},
+			     {36.675, 22.933},
+			     {53.4802, 23.4595},
+			     {74.3939, 25.4994},
+			     {111.071, 29.4632},
+			     {173.835, 33.9251},
+			     {306.106, 38.1019},
+			     {467.921, 37.2352},
+			     {749.809, 31.8425},
+			     {1093.38, 25.495},
+			     {1711.25, 18.3343},
+			     {2615.85, 12.6461},
+			     {3998.65, 8.51594},
+			     {6258.24, 5.23814},
+			     {9794.71, 3.01815},
+			     {16453.1, 1.58294},
+			     {27637.8, 0.779995},
+			     {38445.7, 0.525689},
+			     {49828.3, 0.364016},
+			     {70967.5, 0.228694},
+			     {98719.8, 0.148206},
+			     {127948, 0.116139},
+			     {169785, 0.0957632},
+			     {220053, 0.0900259} };
+  for( int iP = 0; iP < nPts; ++iP ){
+    std::pair<double,double> thePair(modelDL[iP][0],modelDL[iP][1]);
+    output.push_back(thePair);
+  }
+  return output;
+
+
+
+}
+


### PR DESCRIPTION
Modified the access to diffusion coefficients for liquid Xe so that they're independent functions, added a new, toggleable high-field diffusion model based on the Boyle (2016) paper, and added a separate directory for Garfield++ integration.

This resolves git issue #67 (https://github.com/NESTCollaboration/nest/issues/67), at least for liquid Xe.