### PR TITLE
Include stdexcept

### DIFF
--- a/src/GammaHandler.cpp
+++ b/src/GammaHandler.cpp
@@ -1,4 +1,6 @@
+#include <exception>
 #include "GammaHandler.hh"
+#include <stdexcept>
 
 using namespace std;
 


### PR DESCRIPTION
We encountered this similar issue for NEST.cpp. throw std:: requires that we include <stdexcept>