### PR TITLE
add default density argument for LXe case

### DIFF
--- a/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
+++ b/GarfieldppIntegration/GenerateGarfieldGasTableForLiquidNoble.cpp
@@ -211,7 +211,7 @@ void PassTransportInfo(std::ofstream & outFile, std::vector<double> fieldList_V_
     
   for( int iF = 0; iF < fieldList_V_cm.size(); ++iF ){
     double field = fieldList_V_cm[iF]; //Note that this is reduced field, in V/cm/torr
-    double driftVel_CmperUs = n.GetDriftVelocity_Liquid(temperature_K, 1,field*reducedFieldCorrectionFactor)/10.;
+    double driftVel_CmperUs = n.GetDriftVelocity_Liquid(temperature_K, field*reducedFieldCorrectionFactor, 1)/10.;
     double DT_cm2_s = n.GetDiffTran_Liquid(field*reducedFieldCorrectionFactor,true);
     double DL_cm2_s = n.GetDiffLong_Liquid(field*reducedFieldCorrectionFactor,true);
     

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -267,7 +267,7 @@ class NESTcalc {
   // Gives one the drift velocity as a function of temperature and electric
   // field in liquid or solid. If density implies gas, kicks calculation down to
   // the next function below
-  static double GetDriftVelocity_Liquid(double T, double D=2.9, double F);
+  static double GetDriftVelocity_Liquid(double T, double F, double D=2.9);
   // Gives one the drift velocity as a function of temperature and electric
   // field in liquid or solid. If density implies gas, kicks calculation down to
   // the next function below. NOTE: Density default implies liquid

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -267,10 +267,10 @@ class NESTcalc {
   // Gives one the drift velocity as a function of temperature and electric
   // field in liquid or solid. If density implies gas, kicks calculation down to
   // the next function below
-  static double GetDriftVelocity_Liquid(double T, double D, double F);
+  static double GetDriftVelocity_Liquid(double T, double D=2.9, double F);
   // Gives one the drift velocity as a function of temperature and electric
   // field in liquid or solid. If density implies gas, kicks calculation down to
-  // the next function below
+  // the next function below. NOTE: Density default implies liquid
   static double GetDriftVelocity_MagBoltz(double D, double F, double molarMass=131.293);
   // Gas electron drift speed for S2 gas gap in 2-phase TPCs or the whole
   // detector for all gas. Based on simple fits to complicated MagBoltz software

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -1582,11 +1582,11 @@ double NESTcalc::SetDriftVelocity(double Kelvin, double Density, double eField){
 double NESTcalc::GetDriftVelocity(double Kelvin, double Density, double eField, bool inGas){
   if (inGas) return GetDriftVelocity_MagBoltz(Density, eField);
   else
-    return GetDriftVelocity_Liquid ( Kelvin, Density, eField );
+    return GetDriftVelocity_Liquid ( Kelvin, eField, Density);
 }
 
-double NESTcalc::GetDriftVelocity_Liquid(double Kelvin, double Density,
-                                  double eField) {  // for liquid and solid only
+double NESTcalc::GetDriftVelocity_Liquid(double Kelvin, double eField,  
+					 double Density,) {  // for liquid and solid only
   double speed =
       0.0;  // returns drift speed in mm/usec. based on Fig. 14 arXiv:1712.08607
   int i, j;

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -1586,7 +1586,7 @@ double NESTcalc::GetDriftVelocity(double Kelvin, double Density, double eField, 
 }
 
 double NESTcalc::GetDriftVelocity_Liquid(double Kelvin, double eField,  
-					 double Density,) {  // for liquid and solid only
+					 double Density) {  // for liquid and solid only
   double speed =
       0.0;  // returns drift speed in mm/usec. based on Fig. 14 arXiv:1712.08607
   int i, j;


### PR DESCRIPTION
I doubt this will be right, since my C++ isn't sharp. Will this fix the density requirement for those looking to use this function as-is in liquid xenon, and if I provide a default value, do I have to reorder the arguments such that those with defaults are given last?
If it looks good as is that's great too. 

(Referencing #102) 