### PR TITLE
Clearing the photon_areas vector

### DIFF
--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -834,6 +834,9 @@ const vector<double> &NESTcalc::GetS1(const QuantaResult &quanta, double truthPo
     int Nph = quanta.photons;
     double subtract[2] = {0., 0.};
 
+    photon_areas.clear();
+    photon_areas.resize(2);
+
     // This will clear and reset the vector values
     std::fill(scintillation.begin(), scintillation.end(), 0);
 


### PR DESCRIPTION
This fixes an issue about the waveform. 
By not clearing the `photon_areas` vector, the waveforms were stack on each other.