### PR TITLE
Updated the parametric S1 calculation to account for Truncated SPE and DPE distributions

### DIFF
--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -982,6 +982,7 @@ const vector<double> &NESTcalc::GetS1(const QuantaResult &quanta, double truthPo
            eff = fdetector->get_sPEeff();
            if ( eff < 1. )
              eff += ((1.-eff)/(2.*static_cast<double>(fdetector->get_numPMTs())))*static_cast<double>(nHits); //same as Full S1CalculationMode case
+	   // Above efficiency adjustment needs to be 'NPhe' instead of 'nHits' for Flamedisx implementation 
            eff = max ( 0., min ( eff, 1. ) );
            auto Nphe_det = static_cast<double>(BinomFluct( Nphe, 1. - ( 1. - eff ) / ( 1. + fdetector->get_P_dphe())));
            //take into account the truncation of the PE distributions

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -978,15 +978,15 @@ const vector<double> &NESTcalc::GetS1(const QuantaResult &quanta, double truthPo
            double belowThresh_percentile = sPE_belowThresh_percentile * (1. - fdetector->get_P_dphe() )
                                          + dPE_belowThresh_percentile * fdetector->get_P_dphe();
         
-           Nphe = nHits + BinomFluct(nHits, fdetector->get_P_dphe());
+           Nphe = nHits + static_cast<int>BinomFluct(nHits, fdetector->get_P_dphe());
            eff = fdetector->get_sPEeff();
            if ( eff < 1. )
-             eff += ((1.-eff)/(2.*double(fdetector->get_numPMTs())))*double(nHits); //same as Full S1CalculationMode case
+             eff += ((1.-eff)/(2.*static_cast<double>(fdetector->get_numPMTs())))*static_cast<double>(nHits); //same as Full S1CalculationMode case
            eff = max ( 0., min ( eff, 1. ) );
-           double Nphe_det = BinomFluct ( Nphe, 1. - ( 1. - eff ) / ( 1. + fdetector->get_P_dphe() ) );
+           auto Nphe_det = static_cast<double>(BinomFluct( Nphe, 1. - ( 1. - eff ) / ( 1. + fdetector->get_P_dphe())));
            //take into account the truncation of the PE distributions
            pulseArea = RandomGen::rndm()->rand_gauss ( Nphe_det*(1./NewMean), fdetector->get_sPEres() * sqrt(Nphe_det) );
-           spike = (double) BinomFluct( nHits, eff*(1. - belowThresh_percentile) );
+           spike = static_cast<double>(BinomFluct(nHits, eff*(1. - belowThresh_percentile)));
 
 	   break;
         }

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -978,7 +978,7 @@ const vector<double> &NESTcalc::GetS1(const QuantaResult &quanta, double truthPo
            double belowThresh_percentile = sPE_belowThresh_percentile * (1. - fdetector->get_P_dphe() )
                                          + dPE_belowThresh_percentile * fdetector->get_P_dphe();
         
-           Nphe = nHits + static_cast<int>BinomFluct(nHits, fdetector->get_P_dphe());
+           Nphe = nHits + static_cast<int>(BinomFluct(nHits, fdetector->get_P_dphe()));
            eff = fdetector->get_sPEeff();
            if ( eff < 1. )
              eff += ((1.-eff)/(2.*static_cast<double>(fdetector->get_numPMTs())))*static_cast<double>(nHits); //same as Full S1CalculationMode case

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -888,7 +888,7 @@ const vector<double> &NESTcalc::GetS1(const QuantaResult &quanta, double truthPo
     // (some phe will be below threshold)
 
     S1CalculationMode current_mode = mode;
-    if (current_mode == S1CalculationMode::Hybrid && energy > 100. ) { //100 keV_ee at 100 V/cm gives approximately 500 photon hits at g1=10%
+    if (current_mode == S1CalculationMode::Hybrid && energy < 100. ) { //100 keV_ee at 100 V/cm gives approximately 500 photon hits at g1=10%
         current_mode = S1CalculationMode::Full;
     } else if (current_mode == S1CalculationMode::Hybrid) {
         current_mode = S1CalculationMode::Parametric;

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -888,7 +888,7 @@ const vector<double> &NESTcalc::GetS1(const QuantaResult &quanta, double truthPo
     // (some phe will be below threshold)
 
     S1CalculationMode current_mode = mode;
-    if (current_mode == S1CalculationMode::Hybrid && quanta.photons * g1_XYZ < fdetector->get_numPMTs()) {
+    if (current_mode == S1CalculationMode::Hybrid && energy > 100. ) { //100 keV_ee at 100 V/cm gives approximately 500 photon hits at g1=10%
         current_mode = S1CalculationMode::Full;
     } else if (current_mode == S1CalculationMode::Hybrid) {
         current_mode = S1CalculationMode::Parametric;


### PR DESCRIPTION
This should remove the discontinuities seen in the past when transitioning between useTiming=0 and useTiming=-1. This accounts for the SPE and DPE distributions being truncated gaussians (since negative SPE areas are unphysical), which slightly reduces their means. Also matches the efficiency calculations between the "Full" and "Parametric" modes, as they previously differed slightly. 