### PR TITLE
Fixing gcem target when using externally

### DIFF
--- a/cmake/NESTConfig.cmake.in
+++ b/cmake/NESTConfig.cmake.in
@@ -11,6 +11,11 @@ set(NEST_INCLUDE_DIRS
     "${PACKAGE_PREFIX_DIR}/include/Detectors"
 )
 
+# Internal gcem build
+if(NOT TARGET gcem)
+  find_dependency(gcem PATHS "${NEST_CMAKE_DIR}/../gcem")
+endif()
+
 if(NOT TARGET NEST::Core)
     include("${NEST_CMAKE_DIR}/NESTTargets.cmake")
 endif()


### PR DESCRIPTION
This commit fixes gcem target not being configure when using externally. 
The error happened at the level of the cmake configuration: 

```
CMake Error at CMakeLists.txt:5 (find_package):
  Found package configuration file:

    ....../lib64/cmake/NEST/NESTConfig.cmake

  but it set NEST_FOUND to FALSE so package "NEST" is considered to be NOT
  FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing: gcem

```