### PR TITLE
Updated execNEST ER model weighting to match XELDA and LUX L-shell measurements.

### DIFF
--- a/src/execNEST.cpp
+++ b/src/execNEST.cpp
@@ -182,15 +182,15 @@ int main(int argc, char** argv) {
     
     FreeParam.clear();
     NuisParam.clear();
-    if ( type == "ER" ) {
-      FreeParam.push_back(0.500);//LUX Run03
-      FreeParam.push_back(0.5);
-      FreeParam.push_back(1.1);
-      FreeParam.push_back(-5.);
-      FreeParam.push_back(1.01);
-      FreeParam.push_back(0.95);
-      FreeParam.push_back(1.4e-2);
-      FreeParam.push_back(1.8e-2);
+    if ( type == "ER" ) { //Based on XELDA L-shell 5.2 keV yields https://arxiv.org/abs/2109.11487
+      FreeParam.push_back(0.23);//0.5 for LUX Run03
+      FreeParam.push_back(0.77); //0.5
+      FreeParam.push_back(2.95); //1.1
+      FreeParam.push_back(-1.44); //-5.
+      FreeParam.push_back(1.0); //1.01
+      FreeParam.push_back(1.0); //0.95
+      FreeParam.push_back(0.); //1.4e-2 
+      FreeParam.push_back(0.); //1.8e-2
     }
     else {
       FreeParam.push_back(1.00); // Fi (Fano factor for ionization)
@@ -887,7 +887,8 @@ vector<double> signal1, signal2, signalE, vTable;
             YieldResult yieldsG = n.GetYields(gammaRay, keV, rho, field,
                                               double(massNum), double(atomNum), NuisParam);
             double weightG =
-                    FreeParam[0] + FreeParam[1] * erf(FreeParam[2] * (log(keV) + FreeParam[3])); // Xe10:1,.55,-1.6,-1.0
+                    FreeParam[0] + FreeParam[1] * erf(FreeParam[2] * (log(keV) + FreeParam[3])) * (1. - (1./(1. + pow(field/421.15, 3.27)))); // Xe10:1,.55,-1.6,-1.0
+	            //field weighting added to match dependence reported by XELDA and LUX Run3 
             double weightB = 1. - weightG;
             yields.PhotonYield = weightG * yieldsG.PhotonYield + weightB * yieldsB.PhotonYield;
             yields.ElectronYield = weightG * yieldsG.ElectronYield + weightB * yieldsB.ElectronYield;


### PR DESCRIPTION
Updated the parameters for execNEST's beta/gamma weighting function, callable with the "ER" particle type. 

This was tuned to match the light and charge yields reported by XELDA for the 5.2 keV Xe127 L-shell decay, https://arxiv.org/abs/2109.11487

Field dependence was added to this weighting to match both XELDA fields and the LUX Xe127 measurement: https://arxiv.org/abs/1709.00800
 
![XELDA_comparison_betaGR_erfWeighting](https://user-images.githubusercontent.com/31666153/134728822-ac9656fe-cbaa-44d8-b215-e12e58a19bc9.png)
 