### PR TITLE
Removed reference to 'verbosity' in the LUX_Run03.hh file. 

### DIFF
--- a/include/Detectors/LUX_Run03.hh
+++ b/include/Detectors/LUX_Run03.hh
@@ -14,8 +14,8 @@ class DetectorExample_LUX_RUN03: public VDetector {
 public:
   
   DetectorExample_LUX_RUN03() {
-    cerr << "*** Detector definition message ***" << endl;
-    cerr << "You are currently using the LUX Run03 template detector." << endl << endl;
+    //cerr << "*** Detector definition message ***" << endl;
+    //cerr << "You are currently using the LUX Run03 template detector." << endl << endl;
     
     // Call the initialization of all the parameters
     Initialization();

--- a/src/execNEST.cpp
+++ b/src/execNEST.cpp
@@ -37,6 +37,8 @@ int main(int argc, char** argv) {
   // Instantiate your own VDetector class here, then load into NEST class
   // constructor
   auto* detector = new DetectorExample_LUX_RUN03();
+  if ( verbosity ) cerr << "*** Detector definition message ***" << endl;
+  if ( verbosity ) cerr << "You are currently using the LUX Run03 template detector." << endl << endl;
   // Custom parameter modification functions
   // detector->ExampleFunction();
   


### PR DESCRIPTION
This was causing issues for NESTpy, and is a different format from all other detector files. I figured just remove verbosity for now in the detector file and make the declaration message similar to the other detectors. 