### PR TITLE
Faster random draws for Kr model times

### DIFF
--- a/include/NEST/RandomGen.hh
+++ b/include/NEST/RandomGen.hh
@@ -21,7 +21,7 @@ class RandomGen {
   double rand_uniform();
   double rand_gauss(double mean, double sigma);
   double rand_zero_trunc_gauss(double mean, double sigma);
-  double rand_exponential(double half_life);
+  double rand_exponential(double half_life, double t_min=-1, double t_max=-1);
   double rand_skewGauss(double xi, double omega, double alpha);
   int poisson_draw(double mean);
   int64_t binom_draw(int64_t N0, double prob);

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -746,9 +746,8 @@ YieldResult NESTcalc::GetYieldKr83m(double energy, double density,
          << endl;
   }
   if (energy > 9.35 && energy < 9.45) {
-    while (!ValidityTests::nearlyEqual(minTimeSeparation, maxTimeSeparation) &&
-           (deltaT_ns > maxTimeSeparation || deltaT_ns < minTimeSeparation))
-      deltaT_ns = RandomGen::rndm()->rand_exponential(deltaT_ns_halflife);
+    if (!ValidityTests::nearlyEqual(minTimeSeparation, maxTimeSeparation))
+      deltaT_ns = RandomGen::rndm()->rand_exponential(deltaT_ns_halflife, minTimeSeparation, maxTimeSeparation);
     Nq = energy * 1e3 / Wq_eV;
     double medTlevel =
         57.462 + (69.201 - 57.462) / pow(1. + pow(dfield / 250.13, 0.9), 1.);
@@ -768,10 +767,8 @@ YieldResult NESTcalc::GetYieldKr83m(double energy, double density,
       Ne = Nq - Nph;
       if (Ne < 0.) Ne = 0.;
     } else {  // merged 41.5 keV decay
-      while (
-          !ValidityTests::nearlyEqual(minTimeSeparation, maxTimeSeparation) &&
-          (deltaT_ns > maxTimeSeparation || deltaT_ns < minTimeSeparation))
-        deltaT_ns = RandomGen::rndm()->rand_exponential(deltaT_ns_halflife);
+      if (!ValidityTests::nearlyEqual(minTimeSeparation, maxTimeSeparation))
+        deltaT_ns = RandomGen::rndm()->rand_exponential(deltaT_ns_halflife, minTimeSeparation, maxTimeSeparation);
       double medTlevel =
           57.462 + (69.201 - 57.462) / pow(1. + pow(dfield / 250.13, 0.9), 1.);
       double lowTdrop = 35. + (75. - 35.) / pow(1. + pow(dfield / 60, 1), 1);

--- a/src/RandomGen.cpp
+++ b/src/RandomGen.cpp
@@ -44,8 +44,17 @@ double RandomGen::rand_zero_trunc_gauss(double mean, double sigma) {
   return r;
 }
 
-double RandomGen::rand_exponential(double half_life) {
+double RandomGen::rand_exponential(double half_life, double t_min, double t_max) {
   double r = rand_uniform();
+  double r_min = 0;
+  double r_max = 1;
+  if (t_min >= 0){
+    r_min = 1 - exp(-t_min*log2/half_life);
+  }
+  if (t_max >= 0){
+    r_max = 1 - exp(-t_max*log2/half_life);
+  }
+  r = (r_max-r_min)*r + r_min;
   return -log(1 - r) * half_life / log2;
 }
 


### PR DESCRIPTION
Get Kr model random times in a single draw, even when using a restricted time range (modifies rand_exponential options, but same default behavior)