### PR TITLE
Add const to avoid compilation error with G4-v11 and C++17

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -401,7 +401,7 @@ G4VParticleChange* NESTProc::PostStepDoIt(const G4Track& aTrack,
   //... in a noble element...
   const G4Material* preMaterial = aStep.GetPreStepPoint()->GetMaterial();
   const G4Material* postMaterial = aStep.GetPostStepPoint()->GetMaterial();
-  G4Element *ElementA = NULL, *ElementB = NULL;
+  const G4Element *ElementA = NULL, *ElementB = NULL;
   if (preMaterial) {
     const G4ElementVector* theElementVector1 = preMaterial->GetElementVector();
     ElementA = (*theElementVector1)[0];


### PR DESCRIPTION
Hi! I am trying to compile NEST using Geant4-v11 and C++17 and I find the following error :

<img width="1159" alt="Screenshot 2022-03-11 at 15 13 41" src="https://user-images.githubusercontent.com/8114436/157884302-5ca0d0d4-5042-4b06-bef2-255dadd1ad6e.png">

I've tried without using the C++17 configuration flag (`-DCMAKE_CXX_STANDARD=17`) and error remains. I haven't tried with a previous version of Geant4.

This PR fixes the compilation.

