### PR TITLE
Add function to use arbitrary electric field direction in G4

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -93,9 +93,12 @@ G4Track* NESTProc::MakeElectron(G4ThreeVector xyz, double density, double t,
   // Determine polarization of new photon
 
   double efield_here = fDetector->FitEF(xyz.x(), xyz.y(), xyz.z());
+  std::vector<double> efield_vec = fDetector->FitDirEF(xyz.x(), xyz.y(), xyz.z());
+  G4ThreeVector efield_dir_here =
+    G4ThreeVector(efield_vec[0], efield_vec[1], efield_vec[2]);
 
   if (efield_here > 0) {
-    G4ParticleMomentum electronMomentum(0, 0, 1);
+    G4ParticleMomentum electronMomentum = efield_here * efield_dir_here.unit();
     G4DynamicParticle* aQuantum = new G4DynamicParticle(
         NESTThermalElectron::ThermalElectron(), electronMomentum);
     aQuantum->SetKineticEnergy(kin_E);

--- a/include/Detectors/VDetector.hh
+++ b/include/Detectors/VDetector.hh
@@ -128,9 +128,11 @@ class VDetector {
   // s1polA + s1polB*z[mm] + s1polC*z^2+... (QE included, for binom dist) e.g.
   virtual double FitS1(double, double, double, LCE) { return 1.; }
 
-  // Drift electric field as function of Z in mm
+  // Drift electric field intensity as function of the point in mm
   // For example, use a high-order poly spline
   virtual double FitEF(double, double, double) { return 730.; }
+  // Set a custom direction for the electric field (by default constant in Z)
+  virtual std::vector<double> FitDirEF(double, double, double) { return {0, 0, 1}; }
 
   // S2 PDE custom fit for function of r
   // s2polA + s2polB*r[mm] + s2polC*r^2+... (QE included, for binom dist) e.g.


### PR DESCRIPTION
This PR adds the possibility of defining an electric field with a direction different from (0, 0, 1), in the GEANT4 integration.