### PR TITLE
Keep the electron momentum as a unit vector

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -98,7 +98,7 @@ G4Track* NESTProc::MakeElectron(G4ThreeVector xyz, double density, double t,
     G4ThreeVector(efield_vec[0], efield_vec[1], efield_vec[2]);
 
   if (efield_here > 0) {
-    G4ParticleMomentum electronMomentum = efield_here * efield_dir_here.unit();
+    G4ParticleMomentum electronMomentum = efield_dir_here.unit();
     G4DynamicParticle* aQuantum = new G4DynamicParticle(
         NESTThermalElectron::ThermalElectron(), electronMomentum);
     aQuantum->SetKineticEnergy(kin_E);


### PR DESCRIPTION
In my last PR I modified the calculation of the momentum of a thermalelectron to generalize it to a field of arbitrary direction. 
However, it was multiplied erroneously by the magnitude of the field, which is not correct. Notice that this didn't affect the simulation, because GEANT4 normalizes internally the momentum to magnitude 1. However, it could be misleading for someone reading the code, so I fixed it.