### PR TITLE
Gr free param expansion

### DIFF
--- a/examples/bareNEST.cpp
+++ b/examples/bareNEST.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
   NEST::QuantaResult quanta;
 
   // Declare needed temporary variables
-  vector<double> vTable, YieldParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3,
+  vector<double> vTable, NRYieldsParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3,
                                       2.,  0.3, 2.,     0.5,     1.,   1.};
   int index;  // index for Z step (for getting pre-calculated drift field)
   double g2, pos_x, pos_y, pos_z, r, phi, driftTime, field, vD, vD_middle;
@@ -182,9 +182,9 @@ int main(int argc, char** argv) {
 
   // Get yields from NEST calculator, along with number of quanta
   yields = n.GetYields(type_num, keV, rho, field, double(massNum),
-                       double(atomNum), YieldParam);
-  vector<double> WidthParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}; 
-  quanta = n.GetQuanta(yields, rho, WidthParam);
+                       double(atomNum), NRYieldsParam);
+  vector<double> ERNRWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}; 
+  quanta = n.GetQuanta(yields, rho, ERNRWidthsParam);
 
   // Calculate S2 photons using electron lifetime correction
   double Nphd_S2 =

--- a/examples/bareNEST.cpp
+++ b/examples/bareNEST.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
   NEST::QuantaResult quanta;
 
   // Declare needed temporary variables
-  vector<double> vTable, NuisParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3,
+  vector<double> vTable, YieldParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3,
                                       2.,  0.3, 2.,     0.5,     1.,   1.};
   int index;  // index for Z step (for getting pre-calculated drift field)
   double g2, pos_x, pos_y, pos_z, r, phi, driftTime, field, vD, vD_middle;
@@ -182,9 +182,9 @@ int main(int argc, char** argv) {
 
   // Get yields from NEST calculator, along with number of quanta
   yields = n.GetYields(type_num, keV, rho, field, double(massNum),
-                       double(atomNum), NuisParam);
-  vector<double> FreeParam = {1, 1, .1, .5, .19, 2.25};
-  quanta = n.GetQuanta(yields, rho, FreeParam);
+                       double(atomNum), YieldParam);
+  vector<double> WidthParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}; 
+  quanta = n.GetQuanta(yields, rho, WidthParam);
 
   // Calculate S2 photons using electron lifetime correction
   double Nphd_S2 =

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -208,7 +208,7 @@ class NESTcalc {
       default_NuisParam; /* =
                             {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
   static const std::vector<double>
-      default_FreeParam; /* = {1.,1.,0.1,0.5,0.19,2.25} */
+      default_FreeParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
 
   NESTresult FullCalculation(
       INTERACTION_TYPE species, double energy, double density, double dfield,
@@ -217,7 +217,7 @@ class NESTcalc {
           default_NuisParam, /* =
                                 {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
       const std::vector<double> &FreeParam =
-          default_FreeParam, /* = {1.,1.,0.1,0.5,0.19,2.25} */
+          default_FreeParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
       bool do_times =
           true);  // the so-called full NEST calculation puts together all the
                   // individual functions/calculations below
@@ -305,7 +305,7 @@ class NESTcalc {
 
   virtual QuantaResult GetQuanta(
       const YieldResult &yields, double density,
-      const std::vector<double> &FreeParam = {1., 1., 0.1, 0.5, 0.19, 2.25},
+      const std::vector<double> &FreeParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
       bool oldModelER = false);
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between
@@ -314,7 +314,7 @@ class NESTcalc {
 
   virtual double RecombOmegaNR(
       double elecFrac,
-      const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25}*/);
+      const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for nuclear recoils and ions (Lindhard<1)
 
@@ -324,7 +324,8 @@ class NESTcalc {
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for gammas and betas (Lindhard==1)
 
-  virtual double FanoER(double density, double Nq_mean, double efield);
+  virtual double FanoER(double density, double Nq_mean, double efield,
+      const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Fano-factor (and Fano-like additional energy resolution model) for gammas
   // and betas (Lindhard==1)
 

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -205,19 +205,19 @@ class NESTcalc {
   virtual ~NESTcalc();
 
   static const std::vector<double>
-      default_YieldParam; /* =
+      default_NRYieldsParam; /* =
                             {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
   static const std::vector<double>
-      default_WidthParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
+      default_ERNRWidthsParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
 
   NESTresult FullCalculation(
       INTERACTION_TYPE species, double energy, double density, double dfield,
       double A, double Z,
-      const std::vector<double> &YieldParam =
-          default_YieldParam, /* =
+      const std::vector<double> &NRYieldsParam =
+          default_NRYieldsParam, /* =
                                 {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
-      const std::vector<double> &WidthParam =
-          default_WidthParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
+      const std::vector<double> &ERNRWidthsParam =
+          default_ERNRWidthsParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
       bool do_times =
           true);  // the so-called full NEST calculation puts together all the
                   // individual functions/calculations below
@@ -243,7 +243,7 @@ class NESTcalc {
   YieldResult GetYields(
       INTERACTION_TYPE species, double energy, double density, double dfield,
       double A, double Z,
-      const std::vector<double> &YieldParam = {11., 1.1, 0.0480, -0.0533, 12.6,
+      const std::vector<double> &NRYieldsParam = {11., 1.1, 0.0480, -0.0533, 12.6,
                                               0.3, 2., 0.3, 2., 0.5, 1., 1.},
       bool oldModelER = false);
   // the innermost heart of NEST, this provides floating-point average values
@@ -256,19 +256,19 @@ class NESTcalc {
 
   virtual YieldResult GetYieldERWeighted(double energy, double density,
                                          double dfield,
-                                         const std::vector<double> &YieldParam);
+                                         const std::vector<double> &NRYieldsParam);
   // Weights beta/gamma models to account for ER sources with differing
   // recombination profiles (such as L-shell electron-capture interactions)
   
-  virtual NESTresult GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
+  virtual NESTresult GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsParam,
 					  string muonInitPos,
 					  vector<double> eDriftVelTable,
-					  const std::vector<double> &WidthParam);
+					  const std::vector<double> &ERNRWidthsParam);
   // Use dE/dx-based yield models instead of energy-based, as everywhere else
   
   virtual YieldResult GetYieldNR(double energy, double density, double dfield,
                                  double massNum,
-                                 const std::vector<double> &YieldParam = {
+                                 const std::vector<double> &NRYieldsParam = {
                                      11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2.,
                                      0.3, 2., 0.5, 1., 1.});
   // Called by GetYields in the NR (and related) cases
@@ -279,7 +279,7 @@ class NESTcalc {
 
   virtual YieldResult GetYieldIon(double energy, double density, double dfield,
                                   double massNum, double atomNum,
-                                  const std::vector<double> &YieldParam = {
+                                  const std::vector<double> &NRYieldsParam = {
                                       11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2.,
                                       0.3, 2., 0.5, 1., 1.});
   // Called by GetYields in the ion case
@@ -296,7 +296,7 @@ class NESTcalc {
 
   virtual YieldResult GetYieldBetaGR(double energy, double density,
                                      double dfield,
-                                     const std::vector<double> &YieldParam);
+                                     const std::vector<double> &NRYieldsParam);
   // Greg R. version: arXiv:1910.04211
 
   virtual YieldResult YieldResultValidity(YieldResult &res, const double energy,
@@ -305,7 +305,7 @@ class NESTcalc {
 
   virtual QuantaResult GetQuanta(
       const YieldResult &yields, double density,
-      const std::vector<double> &WidthParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
+      const std::vector<double> &ERNRWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
       bool oldModelER = false);
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between
@@ -314,18 +314,18 @@ class NESTcalc {
 
   virtual double RecombOmegaNR(
       double elecFrac,
-      const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
+      const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for nuclear recoils and ions (Lindhard<1)
 
   virtual double RecombOmegaER(double efield, double elecFrac,
-                               const std::vector<double> &WidthParam,
+                               const std::vector<double> &ERNRWidthsParam,
                                bool oldModel = false);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for gammas and betas (Lindhard==1)
 
   virtual double FanoER(double density, double Nq_mean, double efield,
-      const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
+      const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Fano-factor (and Fano-like additional energy resolution model) for gammas
   // and betas (Lindhard==1)
 

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -205,19 +205,19 @@ class NESTcalc {
   virtual ~NESTcalc();
 
   static const std::vector<double>
-      default_NuisParam; /* =
+      default_YieldParam; /* =
                             {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
   static const std::vector<double>
-      default_FreeParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
+      default_WidthParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
 
   NESTresult FullCalculation(
       INTERACTION_TYPE species, double energy, double density, double dfield,
       double A, double Z,
-      const std::vector<double> &NuisParam =
-          default_NuisParam, /* =
+      const std::vector<double> &YieldParam =
+          default_YieldParam, /* =
                                 {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
-      const std::vector<double> &FreeParam =
-          default_FreeParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
+      const std::vector<double> &WidthParam =
+          default_WidthParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
       bool do_times =
           true);  // the so-called full NEST calculation puts together all the
                   // individual functions/calculations below
@@ -243,7 +243,7 @@ class NESTcalc {
   YieldResult GetYields(
       INTERACTION_TYPE species, double energy, double density, double dfield,
       double A, double Z,
-      const std::vector<double> &NuisParam = {11., 1.1, 0.0480, -0.0533, 12.6,
+      const std::vector<double> &YieldParam = {11., 1.1, 0.0480, -0.0533, 12.6,
                                               0.3, 2., 0.3, 2., 0.5, 1., 1.},
       bool oldModelER = false);
   // the innermost heart of NEST, this provides floating-point average values
@@ -256,19 +256,19 @@ class NESTcalc {
 
   virtual YieldResult GetYieldERWeighted(double energy, double density,
                                          double dfield,
-                                         const std::vector<double> &NuisParam);
+                                         const std::vector<double> &YieldParam);
   // Weights beta/gamma models to account for ER sources with differing
   // recombination profiles (such as L-shell electron-capture interactions)
   
-  virtual NESTresult GetYieldERdEOdxBasis(const std::vector<double> &NuisParam,
+  virtual NESTresult GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
 					  string muonInitPos,
 					  vector<double> eDriftVelTable,
-					  const std::vector<double> &FreeParam);
+					  const std::vector<double> &WidthParam);
   // Use dE/dx-based yield models instead of energy-based, as everywhere else
   
   virtual YieldResult GetYieldNR(double energy, double density, double dfield,
                                  double massNum,
-                                 const std::vector<double> &NuisParam = {
+                                 const std::vector<double> &YieldParam = {
                                      11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2.,
                                      0.3, 2., 0.5, 1., 1.});
   // Called by GetYields in the NR (and related) cases
@@ -279,7 +279,7 @@ class NESTcalc {
 
   virtual YieldResult GetYieldIon(double energy, double density, double dfield,
                                   double massNum, double atomNum,
-                                  const std::vector<double> &NuisParam = {
+                                  const std::vector<double> &YieldParam = {
                                       11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2.,
                                       0.3, 2., 0.5, 1., 1.});
   // Called by GetYields in the ion case
@@ -296,7 +296,7 @@ class NESTcalc {
 
   virtual YieldResult GetYieldBetaGR(double energy, double density,
                                      double dfield,
-                                     const std::vector<double> &NuisParam);
+                                     const std::vector<double> &YieldParam);
   // Greg R. version: arXiv:1910.04211
 
   virtual YieldResult YieldResultValidity(YieldResult &res, const double energy,
@@ -305,7 +305,7 @@ class NESTcalc {
 
   virtual QuantaResult GetQuanta(
       const YieldResult &yields, double density,
-      const std::vector<double> &FreeParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
+      const std::vector<double> &WidthParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
       bool oldModelER = false);
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between
@@ -314,18 +314,18 @@ class NESTcalc {
 
   virtual double RecombOmegaNR(
       double elecFrac,
-      const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
+      const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for nuclear recoils and ions (Lindhard<1)
 
   virtual double RecombOmegaER(double efield, double elecFrac,
-                               const std::vector<double> &FreeParam,
+                               const std::vector<double> &WidthParam,
                                bool oldModel = false);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for gammas and betas (Lindhard==1)
 
   virtual double FanoER(double density, double Nq_mean, double efield,
-      const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
+      const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Fano-factor (and Fano-like additional energy resolution model) for gammas
   // and betas (Lindhard==1)
 

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -18,9 +18,9 @@ static constexpr int podLength = 1100;  // roughly 100-1,000 ns for S1
 
 bool kr83m_reported_low_deltaT = false;  // to aid in verbosity
 
-const std::vector<double> NESTcalc::default_YieldParam = {
+const std::vector<double> NESTcalc::default_NRYieldsParam = {
     11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
-const std::vector<double> NESTcalc::default_WidthParam = {
+const std::vector<double> NESTcalc::default_ERNRWidthsParam = {
     1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
              // Fano factor of ~3 at least for ionization when using
              // OldW13eV (look at first 2 values)
@@ -29,13 +29,13 @@ NESTresult NESTcalc::FullCalculation(
     INTERACTION_TYPE species, double energy, double density, double dfield,
     double A, double Z,
     const std::vector<double>
-        &YieldParam /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
-    const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
+        &NRYieldsParam /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
+    const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
     bool do_times /*=true*/) {
   if (density < 1.) fdetector->set_inGas(true);
   NESTresult result;
-  result.yields = GetYields(species, energy, density, dfield, A, Z, YieldParam);
-  result.quanta = GetQuanta(result.yields, density, WidthParam);
+  result.yields = GetYields(species, energy, density, dfield, A, Z, NRYieldsParam);
+  result.quanta = GetQuanta(result.yields, density, ERNRWidthsParam);
   if (do_times)
     result.photon_times = GetPhotonTimes(
         species, result.quanta.photons, result.quanta.excitons, dfield, energy);
@@ -180,29 +180,29 @@ photonstream NESTcalc::GetPhotonTimes(INTERACTION_TYPE species,
 
 double NESTcalc::RecombOmegaNR(
     double elecFrac,
-    const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/) {
-  double omega = WidthParam[2] * exp(-0.5 * pow(elecFrac - WidthParam[3], 2.) /
-                                    (WidthParam[4] * WidthParam[4]));
+    const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/) {
+  double omega = ERNRWidthsParam[2] * exp(-0.5 * pow(elecFrac - ERNRWidthsParam[3], 2.) /
+                                    (ERNRWidthsParam[4] * ERNRWidthsParam[4]));
   if (omega < 0.) omega = 0;
   return omega;
 }
 
 double NESTcalc::RecombOmegaER(double efield, double elecFrac,
-                               const std::vector<double> &WidthParam,
+                               const std::vector<double> &ERNRWidthsParam,
                                bool oldModel) {
   double ampl;
   if (!oldModel)
-    ampl = 0.086036 + (WidthParam[7] - 0.086036) / pow(1. + pow(efield / 295.2, 251.6),
+    ampl = 0.086036 + (ERNRWidthsParam[7] - 0.086036) / pow(1. + pow(efield / 295.2, 251.6),
                                                 0.0069114);  // NEW(GregR)
-    //WidthParam[7] sets the lower-asymptote of field-dependence of ampl
+    //ERNRWidthsParam[7] sets the lower-asymptote of field-dependence of ampl
   else
     ampl = 0.14 + (0.043 - 0.14) / (1. + pow(efield / 1210., 1.25));  // OLD
   if (ampl < 0.) ampl = 0.;
-  double wide = WidthParam[8];  // Width of omega vs. electron-fraction (i.e. recomb. prob.)
-  double cntr = WidthParam[9];  // NEW(GregR) Center of omega vs. elec-frac (OLD value of 0.50 for OLD
+  double wide = ERNRWidthsParam[8];  // Width of omega vs. electron-fraction (i.e. recomb. prob.)
+  double cntr = ERNRWidthsParam[9];  // NEW(GregR) Center of omega vs. elec-frac (OLD value of 0.50 for OLD
                        // ampl above 0.14...)
   if (oldModel) cntr = 0.50;
-  double skew = WidthParam[10];  // Skewness of omega vs. elec-frac distribution
+  double skew = ERNRWidthsParam[10];  // Skewness of omega vs. elec-frac distribution
   double mode = cntr + 2. * inv_sqrt2_PI * skew * wide / sqrt(1. + skew * skew);
   double norm =
       1. / (exp(-0.5 * pow(mode - cntr, 2.) / (wide * wide)) *
@@ -216,7 +216,7 @@ double NESTcalc::RecombOmegaER(double efield, double elecFrac,
 }
 
 double NESTcalc::FanoER(double density, double Nq_mean, double efield,
-                       const std::vector<double> &WidthParam) {
+                       const std::vector<double> &ERNRWidthsParam) {
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))  // liquid argon
     return 0.1115;  // T&I. conflicting reports of .107 (Doke) & ~0.1 elsewhere
   double Fano =
@@ -228,19 +228,19 @@ double NESTcalc::FanoER(double density, double Nq_mean, double efield,
           pow(density,
               3.);  // to get it to be ~0.03 for LXe (E Dahl Ph.D. thesis)
   if (!fdetector->get_inGas())
-    Fano += WidthParam[6] * sqrt(Nq_mean) * pow(efield, 0.5);
+    Fano += ERNRWidthsParam[6] * sqrt(Nq_mean) * pow(efield, 0.5);
   return Fano;
 }
 
 QuantaResult NESTcalc::GetQuanta(
     const YieldResult &yields, double density,
-    const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
+    const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
     bool oldModelER) {
   QuantaResult result{};
   bool HighE;
   int Nq_actual, Ne, Nph, Ni, Nex;
 
-  if (WidthParam.size() < 11) {
+  if (ERNRWidthsParam.size() < 11) {
     throw std::runtime_error(
         "ERROR: You need a minimum of 11 free parameters for the resolution "
         "model.");
@@ -265,7 +265,7 @@ QuantaResult NESTcalc::GetQuanta(
   }
 
   if (ValidityTests::nearlyEqual(yields.Lindhard, 1.)) {
-    double Fano = FanoER(density, Nq_mean, yields.ElectricField, WidthParam);
+    double Fano = FanoER(density, Nq_mean, yields.ElectricField, ERNRWidthsParam);
     Nq_actual = int(floor(
         RandomGen::rndm()->rand_gauss(Nq_mean, sqrt(Fano * Nq_mean)) + 0.5));
     if (Nq_actual < 0 || ValidityTests::nearlyEqual(Nq_mean, 0.)) Nq_actual = 0;
@@ -274,12 +274,12 @@ QuantaResult NESTcalc::GetQuanta(
     Nex = Nq_actual - Ni;
 
   } else {
-    double Fano = WidthParam[0];
+    double Fano = ERNRWidthsParam[0];
     Ni = int(floor(RandomGen::rndm()->rand_gauss(Nq_mean * alf,
                                                  sqrt(Fano * Nq_mean * alf)) +
                    0.5));
     if (Ni < 0) Ni = 0;
-    Fano = WidthParam[1];
+    Fano = ERNRWidthsParam[1];
     Nex = int(floor(RandomGen::rndm()->rand_gauss(
                         Nq_mean * excitonRatio * alf,
                         sqrt(Fano * Nq_mean * excitonRatio * alf)) +
@@ -321,8 +321,8 @@ QuantaResult NESTcalc::GetQuanta(
   // set omega (non-binomial recombination fluctuations parameter) according to
   // whether the Lindhard <1, i.e. this is NR.
   double omega = yields.Lindhard < 1
-                     ? RecombOmegaNR(elecFrac, WidthParam)
-                     : RecombOmegaER(yields.ElectricField, elecFrac, WidthParam,
+                     ? RecombOmegaNR(elecFrac, ERNRWidthsParam)
+                     : RecombOmegaER(yields.ElectricField, elecFrac, ERNRWidthsParam,
                                      oldModelER);
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))
     omega = 0.0;  // Ar has no non-binom sauce
@@ -358,7 +358,7 @@ QuantaResult NESTcalc::GetQuanta(
                      exp(-1. * engy / E1) * exp(-1. * sqrt(fld) / sqrt(F1));
       // if ( std::abs(skewness) <= DBL_MIN ) skewness = DBL_MIN;
     } else {
-      skewness = WidthParam[5];  // 2.25 but ~5-20 also good (for NR). All better
+      skewness = ERNRWidthsParam[5];  // 2.25 but ~5-20 also good (for NR). All better
                                 // than zero, but 0 is OK too
     }  // note to self: find way to make 0 for ion (wall BG) incl. alphas?
   }
@@ -436,14 +436,14 @@ YieldResult NESTcalc::GetYieldGamma(double energy, double density,
 
 YieldResult NESTcalc::GetYieldERWeighted(double energy, double density,
                                          double dfield,
-                                         const std::vector<double> &YieldParam) {
+                                         const std::vector<double> &NRYieldsParam) {
   Wvalue wvalue = WorkFunction(density, fdetector->get_molarMass(),
                                fdetector->get_OldW13eV());
   double Wq_eV = wvalue.Wq_eV;
 
   const std::vector<double> EnergyParams = {0.23, 0.77, 2.95, -1.44};
   const std::vector<double> FieldParams = {421.15, 3.27};
-  YieldResult yieldsB = GetYieldBetaGR(energy, density, dfield, YieldParam);
+  YieldResult yieldsB = GetYieldBetaGR(energy, density, dfield, NRYieldsParam);
   YieldResult yieldsG = GetYieldGamma(energy, density, dfield);
   double weightG =
       EnergyParams[0] +
@@ -468,24 +468,24 @@ YieldResult NESTcalc::GetYieldERWeighted(double energy, double density,
   return YieldResultValidity(result, energy, Wq_eV);
 }
 
-NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
+NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsParam,
 					  string muonInitPos,
 					  vector<double> vTable,
-					  const std::vector<double> &WidthParam) {
-  Wvalue wvalue = WorkFunction(YieldParam[8], fdetector->get_molarMass(),
+					  const std::vector<double> &ERNRWidthsParam) {
+  Wvalue wvalue = WorkFunction(NRYieldsParam[8], fdetector->get_molarMass(),
                                fdetector->get_OldW13eV());
-  double Wq_eV = wvalue.Wq_eV; double rho = YieldParam[8];
+  double Wq_eV = wvalue.Wq_eV; double rho = NRYieldsParam[8];
   double xi = -999., yi = -999., zi = fdetector->get_TopDrift();
   double xf, yf, zf, pos_x, pos_y, pos_z, r, phi, field,
-    eMin = YieldParam[4], z_step = YieldParam[5], inField = YieldParam[6];
+    eMin = NRYieldsParam[4], z_step = NRYieldsParam[5], inField = NRYieldsParam[6];
   if(ValidityTests::nearlyEqual(eMin, 0.) || std::isnan(eMin))
     throw std::runtime_error("Energy cannot be zero or undefined");
   NESTresult result{};
-  xf = YieldParam[0];
-  yf = YieldParam[1];
-  zf = YieldParam[2];
-  if (ValidityTests::nearlyEqual(YieldParam[3], -1.)) {
-    if ( WidthParam[0] < 0. && eMin < 0. ) {
+  xf = NRYieldsParam[0];
+  yf = NRYieldsParam[1];
+  zf = NRYieldsParam[2];
+  if (ValidityTests::nearlyEqual(NRYieldsParam[3], -1.)) {
+    if ( ERNRWidthsParam[0] < 0. && eMin < 0. ) {
       xi = xf - 10.;
       yi = yf;
       zi = zf;
@@ -516,16 +516,16 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
   double dEOdx, eStep, refEnergy;
   if (eMin < 0.) {
     refEnergy = -eMin;
-    if ( YieldParam[10] > 0. && YieldParam[11] != 0. ) {
-      dEOdx = YieldParam[10]*pow(-eMin,YieldParam[11]);
-      if ( YieldParam[12] > 0. )
-	dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,YieldParam[12]*dEOdx,true);
+    if ( NRYieldsParam[10] > 0. && NRYieldsParam[11] != 0. ) {
+      dEOdx = NRYieldsParam[10]*pow(-eMin,NRYieldsParam[11]);
+      if ( NRYieldsParam[12] > 0. )
+	dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,NRYieldsParam[12]*dEOdx,true);
     }
     else
-      dEOdx = CalcElectronLET(-eMin, ATOM_NUM, YieldParam[10]);
+      dEOdx = CalcElectronLET(-eMin, ATOM_NUM, NRYieldsParam[10]);
     eStep =dEOdx * rho * z_step * 1e2;
   } else {
-    refEnergy = YieldParam[9];
+    refEnergy = NRYieldsParam[9];
     eStep = eMin * rho * z_step * 1e2;
   }
   double driftTime, vD, keV = 0., Nq_mean;
@@ -552,38 +552,38 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
     else field = inField;
     if (eMin < 0.) {
       if ((keV + eStep) > -eMin) eStep = -eMin - keV;
-      if ( WidthParam[0] < 0. ) {
-	YieldResult yields{}; Nq_mean = -WidthParam[0] * eStep;
-	double Ni_mean = Nq_mean/(1.+WidthParam[1]); xi_tib = Ni_mean*(WidthParam[3]/4.)*pow(eStep,WidthParam[4]-1.);
-	yields.PhotonYield = Ni_mean * (1.+WidthParam[1]-log(WidthParam[2]+xi_tib)/xi_tib);
+      if ( ERNRWidthsParam[0] < 0. ) {
+	YieldResult yields{}; Nq_mean = -ERNRWidthsParam[0] * eStep;
+	double Ni_mean = Nq_mean/(1.+ERNRWidthsParam[1]); xi_tib = Ni_mean*(ERNRWidthsParam[3]/4.)*pow(eStep,ERNRWidthsParam[4]-1.);
+	yields.PhotonYield = Ni_mean * (1.+ERNRWidthsParam[1]-log(ERNRWidthsParam[2]+xi_tib)/xi_tib);
 	yields.ElectronYield = Nq_mean - yields.PhotonYield;
-	yields.ExcitonRatio = WidthParam[1]; yields.Lindhard = 1.;
+	yields.ExcitonRatio = ERNRWidthsParam[1]; yields.Lindhard = 1.;
 	yields.ElectricField = field; yields.DeltaT_Scint = -999; result.yields = yields;
       }
       else
-	result.yields = GetYieldBetaGR(eStep, rho, field, YieldParam);
+	result.yields = GetYieldBetaGR(eStep, rho, field, NRYieldsParam);
     } else
-      result.yields = GetYieldBetaGR(refEnergy, rho, field, YieldParam);
-    if ( eMin < 0. && WidthParam[0] < 0. ) {
+      result.yields = GetYieldBetaGR(refEnergy, rho, field, NRYieldsParam);
+    if ( eMin < 0. && ERNRWidthsParam[0] < 0. ) {
       QuantaResult quanta{};
       if ( Nq_mean < 1. ) Nq = 0;
-      else Nq = int(ceil(RandomGen::rndm()->rand_gauss(Nq_mean,sqrt(WidthParam[5]*Nq_mean),true)-0.5));
+      else Nq = int(ceil(RandomGen::rndm()->rand_gauss(Nq_mean,sqrt(ERNRWidthsParam[5]*Nq_mean),true)-0.5));
       if ( result.yields.PhotonYield < 1. || Nq <= 0 ) quanta.photons = 0;
-      else quanta.photons = int(ceil(RandomGen::rndm()->rand_gauss(result.yields.PhotonYield,sqrt(WidthParam[6]*result.yields.PhotonYield),true)-0.5));
+      else quanta.photons = int(ceil(RandomGen::rndm()->rand_gauss(result.yields.PhotonYield,sqrt(ERNRWidthsParam[6]*result.yields.PhotonYield),true)-0.5));
       quanta.electrons = Nq - quanta.photons;
-      quanta.ions = int(ceil(double(Nq)/(1.+WidthParam[1])-0.5));
+      quanta.ions = int(ceil(double(Nq)/(1.+ERNRWidthsParam[1])-0.5));
       quanta.excitons = Nq - quanta.ions;
-      quanta.recombProb = 1. - log ( WidthParam[2] + xi_tib ) / xi_tib;
-      quanta.Variance = WidthParam[6] * result.yields.PhotonYield;
+      quanta.recombProb = 1. - log ( ERNRWidthsParam[2] + xi_tib ) / xi_tib;
+      quanta.Variance = ERNRWidthsParam[6] * result.yields.PhotonYield;
       result.quanta = quanta;
       Ne += result.quanta.electrons;
     }
     else
-      result.quanta = GetQuanta(result.yields, rho, default_WidthParam, true);
+      result.quanta = GetQuanta(result.yields, rho, default_ERNRWidthsParam, true);
     if (eMin > 0.)
       Nph += result.quanta.photons * (eStep / refEnergy);
     else {
-      if ( WidthParam[0] >= 0. ) {
+      if ( ERNRWidthsParam[0] >= 0. ) {
 	Nq = result.quanta.photons + result.quanta.electrons;
 	double FanoOverall = 0.0015 * sqrt((-1e3*eMin/Wq_eV)*field);
 	double FanoScint = 20. * FanoOverall;
@@ -597,11 +597,11 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
     int index = int(floor(zz / z_step + 0.5));
     if (index >= vTable.size()) index = vTable.size() - 1;
     if (vTable.size() == 0)
-      vD = YieldParam[7];
+      vD = NRYieldsParam[7];
     else
       vD = vTable[index];
     driftTime = (fdetector->get_TopDrift() - zz) / vD;
-    if ( zz >= fdetector->get_cathode() && WidthParam[0] >= 0. ) {
+    if ( zz >= fdetector->get_cathode() && ERNRWidthsParam[0] >= 0. ) {
       if (eMin > 0.)
 	Ne += result.quanta.electrons * (eStep / refEnergy) * exp(-driftTime / fdetector->get_eLife_us());
       else
@@ -614,13 +614,13 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
     zz += norm[2] * z_step;
     if (eMin < 0.) {
       refEnergy -= eStep;
-      if ( YieldParam[10] > 0. && YieldParam[11] != 0. ) {
-	dEOdx = YieldParam[10]*pow(refEnergy,YieldParam[11]);
-	if ( YieldParam[12] > 0. )
-	  dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,YieldParam[12]*dEOdx,true);
+      if ( NRYieldsParam[10] > 0. && NRYieldsParam[11] != 0. ) {
+	dEOdx = NRYieldsParam[10]*pow(refEnergy,NRYieldsParam[11]);
+	if ( NRYieldsParam[12] > 0. )
+	  dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,NRYieldsParam[12]*dEOdx,true);
       }
       else
-	dEOdx = CalcElectronLET(refEnergy, ATOM_NUM, YieldParam[10]);
+	dEOdx = CalcElectronLET(refEnergy, ATOM_NUM, NRYieldsParam[10]);
       eStep = dEOdx * rho * z_step * 1e2;
     }
     // cerr << keV << "\t\t" << xx << "\t" << yy << "\t" << zz << "\t" << Nph << "\t" << Ne << endl;
@@ -715,11 +715,11 @@ YieldResult NESTcalc::GetYieldNROld(
 YieldResult NESTcalc::GetYieldNR(
     double energy, double density, double dfield, double massNum,
     const std::vector<double>
-        &YieldParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {
+        &NRYieldsParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))
     massNum = fdetector->get_molarMass();
 
-  if (YieldParam.size() < 12) {
+  if (NRYieldsParam.size() < 12) {
     throw std::runtime_error(
         "ERROR: You need a minimum of 12 nuisance parameters for the mean "
         "yields.");
@@ -736,21 +736,21 @@ YieldResult NESTcalc::GetYieldNR(
   }
   ScaleFactor[0] = sqrt(fdetector->get_molarMass() / (double)massNumber);
   ScaleFactor[1] = ScaleFactor[0];
-  double Nq = YieldParam[0] * pow(energy, YieldParam[1]);
+  double Nq = NRYieldsParam[0] * pow(energy, NRYieldsParam[1]);
   if (!fdetector->get_OldW13eV()) Nq *= ZurichEXOW;
   double ThomasImel =
-      YieldParam[2] * pow(dfield, YieldParam[3]) * pow(density / DENSITY, 0.3);
-  double Qy = 1. / (ThomasImel * pow(energy + YieldParam[4], YieldParam[9]));
-  Qy *= 1. - 1. / pow(1. + pow((energy / YieldParam[5]), YieldParam[6]),
-                      YieldParam[10]);
+      NRYieldsParam[2] * pow(dfield, NRYieldsParam[3]) * pow(density / DENSITY, 0.3);
+  double Qy = 1. / (ThomasImel * pow(energy + NRYieldsParam[4], NRYieldsParam[9]));
+  Qy *= 1. - 1. / pow(1. + pow((energy / NRYieldsParam[5]), NRYieldsParam[6]),
+                      NRYieldsParam[10]);
   if (!fdetector->get_OldW13eV()) Qy *= ZurichEXOQ;
   double Ly = Nq / energy - Qy;
   if (Qy < 0.0) Qy = 0.0;
   if (Ly < 0.0) Ly = 0.0;
   double Ne = Qy * energy * ScaleFactor[1];
   double Nph = Ly * energy * ScaleFactor[0] *
-               (1. - 1. / pow(1. + pow((energy / YieldParam[7]), YieldParam[8]),
-                              YieldParam[11]));
+               (1. - 1. / pow(1. + pow((energy / NRYieldsParam[7]), NRYieldsParam[8]),
+                              NRYieldsParam[11]));
   Nq = Nph + Ne;
   double Ni = (4. / ThomasImel) * (exp(Ne * ThomasImel / 4.) - 1.);
   double Nex = (-1. / ThomasImel) *
@@ -797,7 +797,7 @@ YieldResult NESTcalc::GetYieldIon(
     double energy, double density, double dfield, double massNum,
     double atomNum,
     const std::vector<double> &
-        YieldParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {  // simply uses the original Lindhard model, but as cited by Hitachi in:
+        NRYieldsParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {  // simply uses the original Lindhard model, but as cited by Hitachi in:
   // https://indico.cern.ch/event/573069/sessions/230063/attachments/1439101/2214448/Hitachi_XeSAT2017_DM.pdf
 
   double A1 = massNum, A2 = RandomGen::rndm()->SelectRanXeAtom();
@@ -1061,9 +1061,9 @@ YieldResult NESTcalc::GetYieldBeta(double energy, double density,
 
 YieldResult  // NEW
 NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
-                         const std::vector<double> &YieldParam) {
+                         const std::vector<double> &NRYieldsParam) {
   bool oldModelER = false;
-  /*if (RecombOmegaER(0.0, 0.5, YieldParam, oldModelER) < 0.05)
+  /*if (RecombOmegaER(0.0, 0.5, NRYieldsParam, oldModelER) < 0.05)
     cerr << "WARNING! You need to change RecombOmegaER to go along with "
             "GetYieldBetaGR"
          << endl;*/
@@ -1075,7 +1075,7 @@ NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
 
   double Nq = energy * 1e3 / Wq_eV;
   double m1 = 30.66 + (6.1978 - 30.66) / pow(1. + pow(dfield / 73.855, 2.0318),
-                                             0.41883);  // YieldParam[0];
+                                             0.41883);  // NRYieldsParam[0];
   double m5 = Nq / energy / (1 + alpha * erf(0.05 * energy)) - m1;
   double m10 =
       (0.0508273937 + (0.1166087199 - 0.0508273937) /
@@ -1124,7 +1124,7 @@ NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
 YieldResult NESTcalc::GetYields(
     INTERACTION_TYPE species, double energy, double density, double dfield,
     double massNum, double atomNum,
-    const std::vector<double> &YieldParam
+    const std::vector<double> &NRYieldsParam
     /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
     bool oldModelER) {
   switch (species) {
@@ -1138,12 +1138,12 @@ YieldResult NESTcalc::GetYields(
       // statement. Same intrinsic yields, but different energy spectra
       // (TestSpectra)
 
-      return GetYieldNR(energy, density, dfield, massNum, YieldParam);
+      return GetYieldNR(energy, density, dfield, massNum, NRYieldsParam);
 
       // return GetYieldNROld ( energy, 1 );
       break;
     case ion:
-      return GetYieldIon(energy, density, dfield, massNum, atomNum, YieldParam);
+      return GetYieldIon(energy, density, dfield, massNum, atomNum, NRYieldsParam);
       break;
     case gammaRay:
       return GetYieldGamma(energy, density, dfield);
@@ -1161,7 +1161,7 @@ YieldResult NESTcalc::GetYields(
       if (ValidityTests::nearlyEqual(ATOM_NUM, 18.) || oldModelER)
         return GetYieldBeta(energy, density, dfield);  // OLD
       else
-        return GetYieldBetaGR(energy, density, dfield, YieldParam);  // NEW
+        return GetYieldBetaGR(energy, density, dfield, NRYieldsParam);  // NEW
       break;
   }
 }

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -18,9 +18,9 @@ static constexpr int podLength = 1100;  // roughly 100-1,000 ns for S1
 
 bool kr83m_reported_low_deltaT = false;  // to aid in verbosity
 
-const std::vector<double> NESTcalc::default_NuisParam = {
+const std::vector<double> NESTcalc::default_YieldParam = {
     11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
-const std::vector<double> NESTcalc::default_FreeParam = {
+const std::vector<double> NESTcalc::default_WidthParam = {
     1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
              // Fano factor of ~3 at least for ionization when using
              // OldW13eV (look at first 2 values)
@@ -29,13 +29,13 @@ NESTresult NESTcalc::FullCalculation(
     INTERACTION_TYPE species, double energy, double density, double dfield,
     double A, double Z,
     const std::vector<double>
-        &NuisParam /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
-    const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
+        &YieldParam /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
+    const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
     bool do_times /*=true*/) {
   if (density < 1.) fdetector->set_inGas(true);
   NESTresult result;
-  result.yields = GetYields(species, energy, density, dfield, A, Z, NuisParam);
-  result.quanta = GetQuanta(result.yields, density, FreeParam);
+  result.yields = GetYields(species, energy, density, dfield, A, Z, YieldParam);
+  result.quanta = GetQuanta(result.yields, density, WidthParam);
   if (do_times)
     result.photon_times = GetPhotonTimes(
         species, result.quanta.photons, result.quanta.excitons, dfield, energy);
@@ -180,29 +180,29 @@ photonstream NESTcalc::GetPhotonTimes(INTERACTION_TYPE species,
 
 double NESTcalc::RecombOmegaNR(
     double elecFrac,
-    const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/) {
-  double omega = FreeParam[2] * exp(-0.5 * pow(elecFrac - FreeParam[3], 2.) /
-                                    (FreeParam[4] * FreeParam[4]));
+    const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/) {
+  double omega = WidthParam[2] * exp(-0.5 * pow(elecFrac - WidthParam[3], 2.) /
+                                    (WidthParam[4] * WidthParam[4]));
   if (omega < 0.) omega = 0;
   return omega;
 }
 
 double NESTcalc::RecombOmegaER(double efield, double elecFrac,
-                               const std::vector<double> &FreeParam,
+                               const std::vector<double> &WidthParam,
                                bool oldModel) {
   double ampl;
   if (!oldModel)
-    ampl = 0.086036 + (FreeParam[7] - 0.086036) / pow(1. + pow(efield / 295.2, 251.6),
+    ampl = 0.086036 + (WidthParam[7] - 0.086036) / pow(1. + pow(efield / 295.2, 251.6),
                                                 0.0069114);  // NEW(GregR)
-    //FreeParam[7] sets the lower-asymptote of field-dependence of ampl
+    //WidthParam[7] sets the lower-asymptote of field-dependence of ampl
   else
     ampl = 0.14 + (0.043 - 0.14) / (1. + pow(efield / 1210., 1.25));  // OLD
   if (ampl < 0.) ampl = 0.;
-  double wide = FreeParam[8];  // Width of omega vs. electron-fraction (i.e. recomb. prob.)
-  double cntr = FreeParam[9];  // NEW(GregR) Center of omega vs. elec-frac (OLD value of 0.50 for OLD
+  double wide = WidthParam[8];  // Width of omega vs. electron-fraction (i.e. recomb. prob.)
+  double cntr = WidthParam[9];  // NEW(GregR) Center of omega vs. elec-frac (OLD value of 0.50 for OLD
                        // ampl above 0.14...)
   if (oldModel) cntr = 0.50;
-  double skew = FreeParam[10];  // Skewness of omega vs. elec-frac distribution
+  double skew = WidthParam[10];  // Skewness of omega vs. elec-frac distribution
   double mode = cntr + 2. * inv_sqrt2_PI * skew * wide / sqrt(1. + skew * skew);
   double norm =
       1. / (exp(-0.5 * pow(mode - cntr, 2.) / (wide * wide)) *
@@ -216,7 +216,7 @@ double NESTcalc::RecombOmegaER(double efield, double elecFrac,
 }
 
 double NESTcalc::FanoER(double density, double Nq_mean, double efield,
-                       const std::vector<double> &FreeParam) {
+                       const std::vector<double> &WidthParam) {
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))  // liquid argon
     return 0.1115;  // T&I. conflicting reports of .107 (Doke) & ~0.1 elsewhere
   double Fano =
@@ -228,19 +228,19 @@ double NESTcalc::FanoER(double density, double Nq_mean, double efield,
           pow(density,
               3.);  // to get it to be ~0.03 for LXe (E Dahl Ph.D. thesis)
   if (!fdetector->get_inGas())
-    Fano += FreeParam[6] * sqrt(Nq_mean) * pow(efield, 0.5);
+    Fano += WidthParam[6] * sqrt(Nq_mean) * pow(efield, 0.5);
   return Fano;
 }
 
 QuantaResult NESTcalc::GetQuanta(
     const YieldResult &yields, double density,
-    const std::vector<double> &FreeParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
+    const std::vector<double> &WidthParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
     bool oldModelER) {
   QuantaResult result{};
   bool HighE;
   int Nq_actual, Ne, Nph, Ni, Nex;
 
-  if (FreeParam.size() < 11) {
+  if (WidthParam.size() < 11) {
     throw std::runtime_error(
         "ERROR: You need a minimum of 11 free parameters for the resolution "
         "model.");
@@ -265,7 +265,7 @@ QuantaResult NESTcalc::GetQuanta(
   }
 
   if (ValidityTests::nearlyEqual(yields.Lindhard, 1.)) {
-    double Fano = FanoER(density, Nq_mean, yields.ElectricField, FreeParam);
+    double Fano = FanoER(density, Nq_mean, yields.ElectricField, WidthParam);
     Nq_actual = int(floor(
         RandomGen::rndm()->rand_gauss(Nq_mean, sqrt(Fano * Nq_mean)) + 0.5));
     if (Nq_actual < 0 || ValidityTests::nearlyEqual(Nq_mean, 0.)) Nq_actual = 0;
@@ -274,12 +274,12 @@ QuantaResult NESTcalc::GetQuanta(
     Nex = Nq_actual - Ni;
 
   } else {
-    double Fano = FreeParam[0];
+    double Fano = WidthParam[0];
     Ni = int(floor(RandomGen::rndm()->rand_gauss(Nq_mean * alf,
                                                  sqrt(Fano * Nq_mean * alf)) +
                    0.5));
     if (Ni < 0) Ni = 0;
-    Fano = FreeParam[1];
+    Fano = WidthParam[1];
     Nex = int(floor(RandomGen::rndm()->rand_gauss(
                         Nq_mean * excitonRatio * alf,
                         sqrt(Fano * Nq_mean * excitonRatio * alf)) +
@@ -321,8 +321,8 @@ QuantaResult NESTcalc::GetQuanta(
   // set omega (non-binomial recombination fluctuations parameter) according to
   // whether the Lindhard <1, i.e. this is NR.
   double omega = yields.Lindhard < 1
-                     ? RecombOmegaNR(elecFrac, FreeParam)
-                     : RecombOmegaER(yields.ElectricField, elecFrac, FreeParam,
+                     ? RecombOmegaNR(elecFrac, WidthParam)
+                     : RecombOmegaER(yields.ElectricField, elecFrac, WidthParam,
                                      oldModelER);
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))
     omega = 0.0;  // Ar has no non-binom sauce
@@ -358,7 +358,7 @@ QuantaResult NESTcalc::GetQuanta(
                      exp(-1. * engy / E1) * exp(-1. * sqrt(fld) / sqrt(F1));
       // if ( std::abs(skewness) <= DBL_MIN ) skewness = DBL_MIN;
     } else {
-      skewness = FreeParam[5];  // 2.25 but ~5-20 also good (for NR). All better
+      skewness = WidthParam[5];  // 2.25 but ~5-20 also good (for NR). All better
                                 // than zero, but 0 is OK too
     }  // note to self: find way to make 0 for ion (wall BG) incl. alphas?
   }
@@ -436,14 +436,14 @@ YieldResult NESTcalc::GetYieldGamma(double energy, double density,
 
 YieldResult NESTcalc::GetYieldERWeighted(double energy, double density,
                                          double dfield,
-                                         const std::vector<double> &NuisParam) {
+                                         const std::vector<double> &YieldParam) {
   Wvalue wvalue = WorkFunction(density, fdetector->get_molarMass(),
                                fdetector->get_OldW13eV());
   double Wq_eV = wvalue.Wq_eV;
 
   const std::vector<double> EnergyParams = {0.23, 0.77, 2.95, -1.44};
   const std::vector<double> FieldParams = {421.15, 3.27};
-  YieldResult yieldsB = GetYieldBetaGR(energy, density, dfield, NuisParam);
+  YieldResult yieldsB = GetYieldBetaGR(energy, density, dfield, YieldParam);
   YieldResult yieldsG = GetYieldGamma(energy, density, dfield);
   double weightG =
       EnergyParams[0] +
@@ -468,24 +468,24 @@ YieldResult NESTcalc::GetYieldERWeighted(double energy, double density,
   return YieldResultValidity(result, energy, Wq_eV);
 }
 
-NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NuisParam,
+NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &YieldParam,
 					  string muonInitPos,
 					  vector<double> vTable,
-					  const std::vector<double> &FreeParam) {
-  Wvalue wvalue = WorkFunction(NuisParam[8], fdetector->get_molarMass(),
+					  const std::vector<double> &WidthParam) {
+  Wvalue wvalue = WorkFunction(YieldParam[8], fdetector->get_molarMass(),
                                fdetector->get_OldW13eV());
-  double Wq_eV = wvalue.Wq_eV; double rho = NuisParam[8];
+  double Wq_eV = wvalue.Wq_eV; double rho = YieldParam[8];
   double xi = -999., yi = -999., zi = fdetector->get_TopDrift();
   double xf, yf, zf, pos_x, pos_y, pos_z, r, phi, field,
-    eMin = NuisParam[4], z_step = NuisParam[5], inField = NuisParam[6];
+    eMin = YieldParam[4], z_step = YieldParam[5], inField = YieldParam[6];
   if(ValidityTests::nearlyEqual(eMin, 0.) || std::isnan(eMin))
     throw std::runtime_error("Energy cannot be zero or undefined");
   NESTresult result{};
-  xf = NuisParam[0];
-  yf = NuisParam[1];
-  zf = NuisParam[2];
-  if (ValidityTests::nearlyEqual(NuisParam[3], -1.)) {
-    if ( FreeParam[0] < 0. && eMin < 0. ) {
+  xf = YieldParam[0];
+  yf = YieldParam[1];
+  zf = YieldParam[2];
+  if (ValidityTests::nearlyEqual(YieldParam[3], -1.)) {
+    if ( WidthParam[0] < 0. && eMin < 0. ) {
       xi = xf - 10.;
       yi = yf;
       zi = zf;
@@ -516,16 +516,16 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NuisParam,
   double dEOdx, eStep, refEnergy;
   if (eMin < 0.) {
     refEnergy = -eMin;
-    if ( NuisParam[10] > 0. && NuisParam[11] != 0. ) {
-      dEOdx = NuisParam[10]*pow(-eMin,NuisParam[11]);
-      if ( NuisParam[12] > 0. )
-	dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,NuisParam[12]*dEOdx,true);
+    if ( YieldParam[10] > 0. && YieldParam[11] != 0. ) {
+      dEOdx = YieldParam[10]*pow(-eMin,YieldParam[11]);
+      if ( YieldParam[12] > 0. )
+	dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,YieldParam[12]*dEOdx,true);
     }
     else
-      dEOdx = CalcElectronLET(-eMin, ATOM_NUM, NuisParam[10]);
+      dEOdx = CalcElectronLET(-eMin, ATOM_NUM, YieldParam[10]);
     eStep =dEOdx * rho * z_step * 1e2;
   } else {
-    refEnergy = NuisParam[9];
+    refEnergy = YieldParam[9];
     eStep = eMin * rho * z_step * 1e2;
   }
   double driftTime, vD, keV = 0., Nq_mean;
@@ -552,38 +552,38 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NuisParam,
     else field = inField;
     if (eMin < 0.) {
       if ((keV + eStep) > -eMin) eStep = -eMin - keV;
-      if ( FreeParam[0] < 0. ) {
-	YieldResult yields{}; Nq_mean = -FreeParam[0] * eStep;
-	double Ni_mean = Nq_mean/(1.+FreeParam[1]); xi_tib = Ni_mean*(FreeParam[3]/4.)*pow(eStep,FreeParam[4]-1.);
-	yields.PhotonYield = Ni_mean * (1.+FreeParam[1]-log(FreeParam[2]+xi_tib)/xi_tib);
+      if ( WidthParam[0] < 0. ) {
+	YieldResult yields{}; Nq_mean = -WidthParam[0] * eStep;
+	double Ni_mean = Nq_mean/(1.+WidthParam[1]); xi_tib = Ni_mean*(WidthParam[3]/4.)*pow(eStep,WidthParam[4]-1.);
+	yields.PhotonYield = Ni_mean * (1.+WidthParam[1]-log(WidthParam[2]+xi_tib)/xi_tib);
 	yields.ElectronYield = Nq_mean - yields.PhotonYield;
-	yields.ExcitonRatio = FreeParam[1]; yields.Lindhard = 1.;
+	yields.ExcitonRatio = WidthParam[1]; yields.Lindhard = 1.;
 	yields.ElectricField = field; yields.DeltaT_Scint = -999; result.yields = yields;
       }
       else
-	result.yields = GetYieldBetaGR(eStep, rho, field, NuisParam);
+	result.yields = GetYieldBetaGR(eStep, rho, field, YieldParam);
     } else
-      result.yields = GetYieldBetaGR(refEnergy, rho, field, NuisParam);
-    if ( eMin < 0. && FreeParam[0] < 0. ) {
+      result.yields = GetYieldBetaGR(refEnergy, rho, field, YieldParam);
+    if ( eMin < 0. && WidthParam[0] < 0. ) {
       QuantaResult quanta{};
       if ( Nq_mean < 1. ) Nq = 0;
-      else Nq = int(ceil(RandomGen::rndm()->rand_gauss(Nq_mean,sqrt(FreeParam[5]*Nq_mean),true)-0.5));
+      else Nq = int(ceil(RandomGen::rndm()->rand_gauss(Nq_mean,sqrt(WidthParam[5]*Nq_mean),true)-0.5));
       if ( result.yields.PhotonYield < 1. || Nq <= 0 ) quanta.photons = 0;
-      else quanta.photons = int(ceil(RandomGen::rndm()->rand_gauss(result.yields.PhotonYield,sqrt(FreeParam[6]*result.yields.PhotonYield),true)-0.5));
+      else quanta.photons = int(ceil(RandomGen::rndm()->rand_gauss(result.yields.PhotonYield,sqrt(WidthParam[6]*result.yields.PhotonYield),true)-0.5));
       quanta.electrons = Nq - quanta.photons;
-      quanta.ions = int(ceil(double(Nq)/(1.+FreeParam[1])-0.5));
+      quanta.ions = int(ceil(double(Nq)/(1.+WidthParam[1])-0.5));
       quanta.excitons = Nq - quanta.ions;
-      quanta.recombProb = 1. - log ( FreeParam[2] + xi_tib ) / xi_tib;
-      quanta.Variance = FreeParam[6] * result.yields.PhotonYield;
+      quanta.recombProb = 1. - log ( WidthParam[2] + xi_tib ) / xi_tib;
+      quanta.Variance = WidthParam[6] * result.yields.PhotonYield;
       result.quanta = quanta;
       Ne += result.quanta.electrons;
     }
     else
-      result.quanta = GetQuanta(result.yields, rho, default_FreeParam, true);
+      result.quanta = GetQuanta(result.yields, rho, default_WidthParam, true);
     if (eMin > 0.)
       Nph += result.quanta.photons * (eStep / refEnergy);
     else {
-      if ( FreeParam[0] >= 0. ) {
+      if ( WidthParam[0] >= 0. ) {
 	Nq = result.quanta.photons + result.quanta.electrons;
 	double FanoOverall = 0.0015 * sqrt((-1e3*eMin/Wq_eV)*field);
 	double FanoScint = 20. * FanoOverall;
@@ -597,11 +597,11 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NuisParam,
     int index = int(floor(zz / z_step + 0.5));
     if (index >= vTable.size()) index = vTable.size() - 1;
     if (vTable.size() == 0)
-      vD = NuisParam[7];
+      vD = YieldParam[7];
     else
       vD = vTable[index];
     driftTime = (fdetector->get_TopDrift() - zz) / vD;
-    if ( zz >= fdetector->get_cathode() && FreeParam[0] >= 0. ) {
+    if ( zz >= fdetector->get_cathode() && WidthParam[0] >= 0. ) {
       if (eMin > 0.)
 	Ne += result.quanta.electrons * (eStep / refEnergy) * exp(-driftTime / fdetector->get_eLife_us());
       else
@@ -614,13 +614,13 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NuisParam,
     zz += norm[2] * z_step;
     if (eMin < 0.) {
       refEnergy -= eStep;
-      if ( NuisParam[10] > 0. && NuisParam[11] != 0. ) {
-	dEOdx = NuisParam[10]*pow(refEnergy,NuisParam[11]);
-	if ( NuisParam[12] > 0. )
-	  dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,NuisParam[12]*dEOdx,true);
+      if ( YieldParam[10] > 0. && YieldParam[11] != 0. ) {
+	dEOdx = YieldParam[10]*pow(refEnergy,YieldParam[11]);
+	if ( YieldParam[12] > 0. )
+	  dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,YieldParam[12]*dEOdx,true);
       }
       else
-	dEOdx = CalcElectronLET(refEnergy, ATOM_NUM, NuisParam[10]);
+	dEOdx = CalcElectronLET(refEnergy, ATOM_NUM, YieldParam[10]);
       eStep = dEOdx * rho * z_step * 1e2;
     }
     // cerr << keV << "\t\t" << xx << "\t" << yy << "\t" << zz << "\t" << Nph << "\t" << Ne << endl;
@@ -715,11 +715,11 @@ YieldResult NESTcalc::GetYieldNROld(
 YieldResult NESTcalc::GetYieldNR(
     double energy, double density, double dfield, double massNum,
     const std::vector<double>
-        &NuisParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {
+        &YieldParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))
     massNum = fdetector->get_molarMass();
 
-  if (NuisParam.size() < 12) {
+  if (YieldParam.size() < 12) {
     throw std::runtime_error(
         "ERROR: You need a minimum of 12 nuisance parameters for the mean "
         "yields.");
@@ -736,21 +736,21 @@ YieldResult NESTcalc::GetYieldNR(
   }
   ScaleFactor[0] = sqrt(fdetector->get_molarMass() / (double)massNumber);
   ScaleFactor[1] = ScaleFactor[0];
-  double Nq = NuisParam[0] * pow(energy, NuisParam[1]);
+  double Nq = YieldParam[0] * pow(energy, YieldParam[1]);
   if (!fdetector->get_OldW13eV()) Nq *= ZurichEXOW;
   double ThomasImel =
-      NuisParam[2] * pow(dfield, NuisParam[3]) * pow(density / DENSITY, 0.3);
-  double Qy = 1. / (ThomasImel * pow(energy + NuisParam[4], NuisParam[9]));
-  Qy *= 1. - 1. / pow(1. + pow((energy / NuisParam[5]), NuisParam[6]),
-                      NuisParam[10]);
+      YieldParam[2] * pow(dfield, YieldParam[3]) * pow(density / DENSITY, 0.3);
+  double Qy = 1. / (ThomasImel * pow(energy + YieldParam[4], YieldParam[9]));
+  Qy *= 1. - 1. / pow(1. + pow((energy / YieldParam[5]), YieldParam[6]),
+                      YieldParam[10]);
   if (!fdetector->get_OldW13eV()) Qy *= ZurichEXOQ;
   double Ly = Nq / energy - Qy;
   if (Qy < 0.0) Qy = 0.0;
   if (Ly < 0.0) Ly = 0.0;
   double Ne = Qy * energy * ScaleFactor[1];
   double Nph = Ly * energy * ScaleFactor[0] *
-               (1. - 1. / pow(1. + pow((energy / NuisParam[7]), NuisParam[8]),
-                              NuisParam[11]));
+               (1. - 1. / pow(1. + pow((energy / YieldParam[7]), YieldParam[8]),
+                              YieldParam[11]));
   Nq = Nph + Ne;
   double Ni = (4. / ThomasImel) * (exp(Ne * ThomasImel / 4.) - 1.);
   double Nex = (-1. / ThomasImel) *
@@ -797,7 +797,7 @@ YieldResult NESTcalc::GetYieldIon(
     double energy, double density, double dfield, double massNum,
     double atomNum,
     const std::vector<double> &
-        NuisParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {  // simply uses the original Lindhard model, but as cited by Hitachi in:
+        YieldParam /*{11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/) {  // simply uses the original Lindhard model, but as cited by Hitachi in:
   // https://indico.cern.ch/event/573069/sessions/230063/attachments/1439101/2214448/Hitachi_XeSAT2017_DM.pdf
 
   double A1 = massNum, A2 = RandomGen::rndm()->SelectRanXeAtom();
@@ -1061,9 +1061,9 @@ YieldResult NESTcalc::GetYieldBeta(double energy, double density,
 
 YieldResult  // NEW
 NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
-                         const std::vector<double> &NuisParam) {
+                         const std::vector<double> &YieldParam) {
   bool oldModelER = false;
-  /*if (RecombOmegaER(0.0, 0.5, NuisParam, oldModelER) < 0.05)
+  /*if (RecombOmegaER(0.0, 0.5, YieldParam, oldModelER) < 0.05)
     cerr << "WARNING! You need to change RecombOmegaER to go along with "
             "GetYieldBetaGR"
          << endl;*/
@@ -1075,7 +1075,7 @@ NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
 
   double Nq = energy * 1e3 / Wq_eV;
   double m1 = 30.66 + (6.1978 - 30.66) / pow(1. + pow(dfield / 73.855, 2.0318),
-                                             0.41883);  // NuisParam[0];
+                                             0.41883);  // YieldParam[0];
   double m5 = Nq / energy / (1 + alpha * erf(0.05 * energy)) - m1;
   double m10 =
       (0.0508273937 + (0.1166087199 - 0.0508273937) /
@@ -1124,7 +1124,7 @@ NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
 YieldResult NESTcalc::GetYields(
     INTERACTION_TYPE species, double energy, double density, double dfield,
     double massNum, double atomNum,
-    const std::vector<double> &NuisParam
+    const std::vector<double> &YieldParam
     /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
     bool oldModelER) {
   switch (species) {
@@ -1138,12 +1138,12 @@ YieldResult NESTcalc::GetYields(
       // statement. Same intrinsic yields, but different energy spectra
       // (TestSpectra)
 
-      return GetYieldNR(energy, density, dfield, massNum, NuisParam);
+      return GetYieldNR(energy, density, dfield, massNum, YieldParam);
 
       // return GetYieldNROld ( energy, 1 );
       break;
     case ion:
-      return GetYieldIon(energy, density, dfield, massNum, atomNum, NuisParam);
+      return GetYieldIon(energy, density, dfield, massNum, atomNum, YieldParam);
       break;
     case gammaRay:
       return GetYieldGamma(energy, density, dfield);
@@ -1161,7 +1161,7 @@ YieldResult NESTcalc::GetYields(
       if (ValidityTests::nearlyEqual(ATOM_NUM, 18.) || oldModelER)
         return GetYieldBeta(energy, density, dfield);  // OLD
       else
-        return GetYieldBetaGR(energy, density, dfield, NuisParam);  // NEW
+        return GetYieldBetaGR(energy, density, dfield, YieldParam);  // NEW
       break;
   }
 }

--- a/src/execNEST.cpp
+++ b/src/execNEST.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace NEST;
 
-vector<double> WidthParam, YieldParam, ERWeightParam;
+vector<double> ERNRWidthsParam, NRYieldsParam, ERWeightParam;
 double band[NUMBINS_MAX][7], energies[3],
     AnnModERange[2] = {1.5, 6.5};  // keVee or nr (recon)
 bool BeenHere = false;
@@ -113,24 +113,24 @@ int main(int argc, char** argv) {
     fPos = -1.;
     seed = 0;
     no_seed = false;
-    WidthParam.clear();
-    YieldParam.clear();
+    ERNRWidthsParam.clear();
+    NRYieldsParam.clear();
     ERWeightParam.clear();
     verbosity = false;
     
-    YieldParam.push_back(0.0);
-    YieldParam.push_back(0.);
-    YieldParam.push_back(300.);
-    YieldParam.push_back(eMax);
-    YieldParam.push_back(eMin);
-    YieldParam.push_back(atof(argv[1]));
-    YieldParam.push_back(inField);
-    YieldParam.push_back(1.51);
-    YieldParam.push_back(2.888);
-    YieldParam.push_back(1e3);
-    YieldParam.push_back(atof(argv[2]));
-    YieldParam.push_back(atof(argv[3]));
-    YieldParam.push_back(atof(argv[4]));
+    NRYieldsParam.push_back(0.0);
+    NRYieldsParam.push_back(0.);
+    NRYieldsParam.push_back(300.);
+    NRYieldsParam.push_back(eMax);
+    NRYieldsParam.push_back(eMin);
+    NRYieldsParam.push_back(atof(argv[1]));
+    NRYieldsParam.push_back(inField);
+    NRYieldsParam.push_back(1.51);
+    NRYieldsParam.push_back(2.888);
+    NRYieldsParam.push_back(1e3);
+    NRYieldsParam.push_back(atof(argv[2]));
+    NRYieldsParam.push_back(atof(argv[3]));
+    NRYieldsParam.push_back(atof(argv[4]));
     
     ERWeightParam.push_back(-atof(argv[5]));
     ERWeightParam.push_back(atof(argv[6]));
@@ -140,17 +140,17 @@ int main(int argc, char** argv) {
     ERWeightParam.push_back(atof(argv[10]));
     ERWeightParam.push_back(atof(argv[11]));
 
-    WidthParam.push_back(1.00);  // Leave fluctuations parameters
-    WidthParam.push_back(1.00);  // fixed for now
-    WidthParam.push_back(0.10);  
-    WidthParam.push_back(0.50);  
-    WidthParam.push_back(0.19);  
-    WidthParam.push_back(2.25);  
-    WidthParam.push_back( 0.0015 ); 
-    WidthParam.push_back( 0.0553 ); 
-    WidthParam.push_back( 0.205 );
-    WidthParam.push_back( 0.45 );
-    WidthParam.push_back( -0.2 );
+    ERNRWidthsParam.push_back(1.00);  // Leave fluctuations parameters
+    ERNRWidthsParam.push_back(1.00);  // fixed for now
+    ERNRWidthsParam.push_back(0.10);  
+    ERNRWidthsParam.push_back(0.50);  
+    ERNRWidthsParam.push_back(0.19);  
+    ERNRWidthsParam.push_back(2.25);  
+    ERNRWidthsParam.push_back( 0.0015 ); 
+    ERNRWidthsParam.push_back( 0.0553 ); 
+    ERNRWidthsParam.push_back( 0.205 );
+    ERNRWidthsParam.push_back( 0.45 );
+    ERNRWidthsParam.push_back( -0.2 );
     
     
   } else {
@@ -177,21 +177,21 @@ int main(int argc, char** argv) {
       no_seed = true;
     }
 
-    WidthParam.clear();
-    YieldParam.clear();
+    ERNRWidthsParam.clear();
+    NRYieldsParam.clear();
     ERWeightParam.clear();
-    WidthParam.push_back(1.00);  // NR Fi (Fano factor for ionization)
-    WidthParam.push_back(1.00);  // NR Fex
-    WidthParam.push_back(
+    ERNRWidthsParam.push_back(1.00);  // NR Fi (Fano factor for ionization)
+    ERNRWidthsParam.push_back(1.00);  // NR Fex
+    ERNRWidthsParam.push_back(
         0.10);  // amplitude for non-binomial NR recombination fluctuations
-    WidthParam.push_back(0.50);  // center in e-Frac (NR)
-    WidthParam.push_back(0.19);  // width parameter (Gaussian 1-sigma)
-    WidthParam.push_back(2.25);  // raw skewness, for NR
-    WidthParam.push_back( 0.0015 ); //ER Fano normalization for non-density dependence
-    WidthParam.push_back( 0.0553 ); //Minimum amplitude for ER non-binom recomb flucts
-    WidthParam.push_back( 0.205 ); // center in e-frac (ER)
-    WidthParam.push_back( 0.45 );  // width parameter
-    WidthParam.push_back( -0.2 );  // ER non-binom skewness in e-frac
+    ERNRWidthsParam.push_back(0.50);  // center in e-Frac (NR)
+    ERNRWidthsParam.push_back(0.19);  // width parameter (Gaussian 1-sigma)
+    ERNRWidthsParam.push_back(2.25);  // raw skewness, for NR
+    ERNRWidthsParam.push_back( 0.0015 ); //ER Fano normalization for non-density dependence
+    ERNRWidthsParam.push_back( 0.0553 ); //Minimum amplitude for ER non-binom recomb flucts
+    ERNRWidthsParam.push_back( 0.205 ); // center in e-frac (ER)
+    ERNRWidthsParam.push_back( 0.45 );  // width parameter
+    ERNRWidthsParam.push_back( -0.2 );  // ER non-binom skewness in e-frac
 
 
     // if (type == "ER") {  // Based on XELDA L-shell 5.2 keV yields
@@ -206,36 +206,36 @@ int main(int argc, char** argv) {
     ERWeightParam.push_back(0.);     // 1.8e-2
      
     if (ValidityTests::nearlyEqual(ATOM_NUM, 18.)) {  // liquid Ar
-      YieldParam.push_back(
+      NRYieldsParam.push_back(
           11.1025);  // +/-1.10 Everything from
                      // https://docs.google.com/document/d/1vLg8vvY5bcdl4Ah4fzyE182DGWt0Wr7_FJ12_B10ujU
-      YieldParam.push_back(1.087399);  // +/-0.025
-      YieldParam.push_back(0.1);       // +/-0.005
-      YieldParam.push_back(-0.0932);   // +/-0.0095
-      YieldParam.push_back(2.998);     // +/-1.026
-      YieldParam.push_back(0.3);       // Fixed
-      YieldParam.push_back(2.94);      // +/-0.12
-      YieldParam.push_back(W_DEFAULT / 1000.);
-      YieldParam.push_back(DBL_MAX);
-      YieldParam.push_back(0.5);  // square root
-      YieldParam.push_back(1.0);
-      YieldParam.push_back(1.0);
+      NRYieldsParam.push_back(1.087399);  // +/-0.025
+      NRYieldsParam.push_back(0.1);       // +/-0.005
+      NRYieldsParam.push_back(-0.0932);   // +/-0.0095
+      NRYieldsParam.push_back(2.998);     // +/-1.026
+      NRYieldsParam.push_back(0.3);       // Fixed
+      NRYieldsParam.push_back(2.94);      // +/-0.12
+      NRYieldsParam.push_back(W_DEFAULT / 1000.);
+      NRYieldsParam.push_back(DBL_MAX);
+      NRYieldsParam.push_back(0.5);  // square root
+      NRYieldsParam.push_back(1.0);
+      NRYieldsParam.push_back(1.0);
     } else {
-      YieldParam.push_back(
+      NRYieldsParam.push_back(
           11.);  // alpha, for NR model. See http://nest.physics.ucdavis.edu
-      YieldParam.push_back(1.1);      // beta
-      YieldParam.push_back(0.0480);   // gamma
-      YieldParam.push_back(-0.0533);  // delta
-      YieldParam.push_back(12.6);     // epsilon
-      YieldParam.push_back(0.3);      // zeta
-      YieldParam.push_back(2.);       // eta
-      YieldParam.push_back(0.3);      // theta
-      YieldParam.push_back(2.);       // iota
+      NRYieldsParam.push_back(1.1);      // beta
+      NRYieldsParam.push_back(0.0480);   // gamma
+      NRYieldsParam.push_back(-0.0533);  // delta
+      NRYieldsParam.push_back(12.6);     // epsilon
+      NRYieldsParam.push_back(0.3);      // zeta
+      NRYieldsParam.push_back(2.);       // eta
+      NRYieldsParam.push_back(0.3);      // theta
+      NRYieldsParam.push_back(2.);       // iota
       // last 3 are the secret extra parameters for additional flexibility
-      YieldParam.push_back(0.5);  // changes sqrt in Qy equation
-      YieldParam.push_back(
+      NRYieldsParam.push_back(0.5);  // changes sqrt in Qy equation
+      NRYieldsParam.push_back(
           1.0);  // makes low-E sigmoid an asymmetric one, for charge
-      YieldParam.push_back(
+      NRYieldsParam.push_back(
           1.0);  // makes low-E sigmoid an asymmetric one, for light
     }
   }
@@ -258,8 +258,8 @@ NESTObservableArray runNESTvec(
   QuantaResult quanta;
   double x, y, z, driftTime, vD;
   RandomGen::rndm()->SetSeed(seed);
-  YieldParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
-  WidthParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
+  NRYieldsParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
+  ERNRWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
   vector<double> scint, scint2, wf_amp;
   vector<int64_t> wf_time;
   NESTObservableArray OutputResults;
@@ -279,8 +279,8 @@ NESTObservableArray runNESTvec(
     double smearPos[3] = {x, y, z};  // ignoring the difference in this quick
                                      // function caused by smearing
     result = n.FullCalculation(particleType, eList[i], rho, useField,
-                               detector->get_molarMass(), ATOM_NUM, YieldParam,
-                               WidthParam, verbosity);
+                               detector->get_molarMass(), ATOM_NUM, NRYieldsParam,
+                               ERNRWidthsParam, verbosity);
     quanta = result.quanta;
     vD = n.SetDriftVelocity(detector->get_T_Kelvin(), rho, useField);
     scint = n.GetS1(quanta, truthPos[0], truthPos[1], truthPos[2], smearPos[0],
@@ -562,11 +562,11 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
   if (type_num == WIMP) {
     yieldsMax =
         n.GetYields(NR, 25.0, rho, centralField, detector->get_molarMass(),
-                    double(atomNum), YieldParam);
+                    double(atomNum), NRYieldsParam);
   } else if (type_num == B8) {
     yieldsMax =
         n.GetYields(NR, 4.00, rho, centralField, detector->get_molarMass(),
-                    double(atomNum), YieldParam);
+                    double(atomNum), NRYieldsParam);
   } else {
     double energyMaximum;
     if (eMax < 0.)
@@ -576,10 +576,10 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
     if ( !energyMaximum || std::isnan(energyMaximum) ) energyMaximum = 1.;
     if (type_num == Kr83m)
       yieldsMax =
-          n.GetYields(Kr83m, eMin, rho, centralField, 400., 100., YieldParam);
+          n.GetYields(Kr83m, eMin, rho, centralField, 400., 100., NRYieldsParam);
     else
       yieldsMax = n.GetYields(type_num, energyMaximum, rho, centralField,
-                              double(massNum), double(atomNum), YieldParam);
+                              double(massNum), double(atomNum), NRYieldsParam);
   }
   if ((g1 * yieldsMax.PhotonYield) > (2. * maxS1) && eMin != eMax &&
       type_num != Kr83m && verbosity && !dEOdxBasis)
@@ -901,23 +901,23 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
       QuantaResult quanta;
       NESTresult result;
       if (dEOdxBasis) {
-	YieldParam[0] = pos_x;
-	YieldParam[1] = pos_y;
-	YieldParam[2] = pos_z;
-	YieldParam[7] = vD_middle;
-	YieldParam[8] = rho;
-	if ( loopNEST ) YieldParam[4] = -TestSpectra::CH3T_spectrum(0.,18.6);
+	NRYieldsParam[0] = pos_x;
+	NRYieldsParam[1] = pos_y;
+	NRYieldsParam[2] = pos_z;
+	NRYieldsParam[7] = vD_middle;
+	NRYieldsParam[8] = rho;
+	if ( loopNEST ) NRYieldsParam[4] = -TestSpectra::CH3T_spectrum(0.,18.6);
 	if ( j == 0 && !loopNEST ) {
-	  YieldParam[3] = eMax;
-	  YieldParam[4] = eMin;
-	  YieldParam[5] = z_step; //5mm for fast, 6um for accurate; .01mm LUXRun3 WS
-	  YieldParam[6] = inField;
-	  YieldParam[9] = 1e3;//MeV
-	  YieldParam[10] = 0.; //+/-1=true, means use continuous slowing-down approx
-	  YieldParam[11] = 0.; //use w/[10] for dE/dx = [10]*keV^[11] e.g. 50 & -0.5
-	  YieldParam[12] = 0.; //fractional variation: e.g .15 = 15%
+	  NRYieldsParam[3] = eMax;
+	  NRYieldsParam[4] = eMin;
+	  NRYieldsParam[5] = z_step; //5mm for fast, 6um for accurate; .01mm LUXRun3 WS
+	  NRYieldsParam[6] = inField;
+	  NRYieldsParam[9] = 1e3;//MeV
+	  NRYieldsParam[10] = 0.; //+/-1=true, means use continuous slowing-down approx
+	  NRYieldsParam[11] = 0.; //use w/[10] for dE/dx = [10]*keV^[11] e.g. 50 & -0.5
+	  NRYieldsParam[12] = 0.; //fractional variation: e.g .15 = 15%
 	}
-	result = n.GetYieldERdEOdxBasis(YieldParam, posiMuon, vTable, ERWeightParam);
+	result = n.GetYieldERdEOdxBasis(NRYieldsParam, posiMuon, vTable, ERWeightParam);
 	yields = result.yields;
 	quanta = result.quanta;
 	if ( ERWeightParam[0] >= 0. )
@@ -942,24 +942,24 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
                       "Xe-129/131m, at low field"
                    << endl;
             }
-            yields = n.GetYieldERWeighted(keV, rho, field, YieldParam);
+            yields = n.GetYieldERWeighted(keV, rho, field, NRYieldsParam);
           } else {
             if (seed < 0 && seed != -1 && type_num <= 5)
               massNum = detector->get_molarMass();
             if (type_num == 11) atomNum = minTimeSeparation;  // Kr83m
             yields = n.GetYields(type_num, keV, rho, field, double(massNum),
-                                 double(atomNum), YieldParam);
+                                 double(atomNum), NRYieldsParam);
           }
           if (type_num == ion) {  // alphas +other nuclei, lighter/heavier than
                                   // medium's default nucleus
-            WidthParam.clear();
-            WidthParam = {
+            ERNRWidthsParam.clear();
+            ERNRWidthsParam = {
                 1.00, 1.00, 0.,
                 0.50, 0.19, 0.,
                 0.0015, 0.0553, 
                 0.205, 0.45, -0.2};  // zero out non-binom recomb fluct & skew (NR)
           }
-          if (!dEOdxBasis) quanta = n.GetQuanta(yields, rho, WidthParam);
+          if (!dEOdxBasis) quanta = n.GetQuanta(yields, rho, ERNRWidthsParam);
         } else {
           yields.PhotonYield = 0.;
           yields.ElectronYield = 0.;
@@ -1010,7 +1010,7 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
                        g2_params);
       if ( dEOdxBasis && !loopNEST ) {
         driftTime = (detector->get_TopDrift() - pos_z) / vD_middle;
-	if ( scint2[7] != -PHE_MIN && WidthParam[0] >= 0. )
+	if ( scint2[7] != -PHE_MIN && ERNRWidthsParam[0] >= 0. )
 	  scint2[7] *= exp(driftTime / detector->get_eLife_us());
       }
 
@@ -1114,12 +1114,12 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
             keV = (Nph / FudgeFactor[0] + Ne / FudgeFactor[1]) * Wq_eV * 1e-3;
           else {
             if (type_num <= NEST::INTERACTION_TYPE::Cf) {
-              keV = pow((Ne + Nph) / YieldParam[0], 1. / YieldParam[1]);
-              Ne *= 1. - 1. / pow(1. + pow((keV / YieldParam[5]), YieldParam[6]),
-                                  YieldParam[10]);
-              Nph *= 1. - 1. / pow(1. + pow((keV / YieldParam[7]), YieldParam[8]),
-                                   YieldParam[11]);
-              keV = pow((Ne + Nph) / YieldParam[0], 1. / YieldParam[1]);
+              keV = pow((Ne + Nph) / NRYieldsParam[0], 1. / NRYieldsParam[1]);
+              Ne *= 1. - 1. / pow(1. + pow((keV / NRYieldsParam[5]), NRYieldsParam[6]),
+                                  NRYieldsParam[10]);
+              Nph *= 1. - 1. / pow(1. + pow((keV / NRYieldsParam[7]), NRYieldsParam[8]),
+                                   NRYieldsParam[11]);
+              keV = pow((Ne + Nph) / NRYieldsParam[0], 1. / NRYieldsParam[1]);
             } else {
               const double logden = log10(rho);
               const double Wq_eV_alpha =
@@ -1245,9 +1245,9 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
         if (seed < 0 && seed != -1) {  // for when you want means
 	  if (dEOdxBasis) {
 	    if (eMin < 0.)
-	      { yields.PhotonYield = -quanta.photons/YieldParam[4]; yields.ElectronYield = -quanta.electrons/YieldParam[4]; }
+	      { yields.PhotonYield = -quanta.photons/NRYieldsParam[4]; yields.ElectronYield = -quanta.electrons/NRYieldsParam[4]; }
 	    else
-	      { yields.PhotonYield /= YieldParam[10]; yields.ElectronYield /= YieldParam[10]; }
+	      { yields.PhotonYield /= NRYieldsParam[10]; yields.ElectronYield /= NRYieldsParam[10]; }
 	  }
           printf("%.6f\t%.6f\t%.6f\t%.0f, %.0f, %.0f\t%lf\t%lf\t", keV, field,
                  driftTime, smearPos[0], smearPos[1], smearPos[2],

--- a/src/execNEST.cpp
+++ b/src/execNEST.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace NEST;
 
-vector<double> FreeParam, NuisParam, ERWeightParam;
+vector<double> WidthParam, YieldParam, ERWeightParam;
 double band[NUMBINS_MAX][7], energies[3],
     AnnModERange[2] = {1.5, 6.5};  // keVee or nr (recon)
 bool BeenHere = false;
@@ -113,24 +113,24 @@ int main(int argc, char** argv) {
     fPos = -1.;
     seed = 0;
     no_seed = false;
-    FreeParam.clear();
-    NuisParam.clear();
+    WidthParam.clear();
+    YieldParam.clear();
     ERWeightParam.clear();
     verbosity = false;
     
-    NuisParam.push_back(0.0);
-    NuisParam.push_back(0.);
-    NuisParam.push_back(300.);
-    NuisParam.push_back(eMax);
-    NuisParam.push_back(eMin);
-    NuisParam.push_back(atof(argv[1]));
-    NuisParam.push_back(inField);
-    NuisParam.push_back(1.51);
-    NuisParam.push_back(2.888);
-    NuisParam.push_back(1e3);
-    NuisParam.push_back(atof(argv[2]));
-    NuisParam.push_back(atof(argv[3]));
-    NuisParam.push_back(atof(argv[4]));
+    YieldParam.push_back(0.0);
+    YieldParam.push_back(0.);
+    YieldParam.push_back(300.);
+    YieldParam.push_back(eMax);
+    YieldParam.push_back(eMin);
+    YieldParam.push_back(atof(argv[1]));
+    YieldParam.push_back(inField);
+    YieldParam.push_back(1.51);
+    YieldParam.push_back(2.888);
+    YieldParam.push_back(1e3);
+    YieldParam.push_back(atof(argv[2]));
+    YieldParam.push_back(atof(argv[3]));
+    YieldParam.push_back(atof(argv[4]));
     
     ERWeightParam.push_back(-atof(argv[5]));
     ERWeightParam.push_back(atof(argv[6]));
@@ -140,17 +140,17 @@ int main(int argc, char** argv) {
     ERWeightParam.push_back(atof(argv[10]));
     ERWeightParam.push_back(atof(argv[11]));
 
-    FreeParam.push_back(1.00);  // Leave fluctuations parameters
-    FreeParam.push_back(1.00);  // fixed for now
-    FreeParam.push_back(0.10);  
-    FreeParam.push_back(0.50);  
-    FreeParam.push_back(0.19);  
-    FreeParam.push_back(2.25);  
-    FreeParam.push_back( 0.0015 ); 
-    FreeParam.push_back( 0.0553 ); 
-    FreeParam.push_back( 0.205 );
-    FreeParam.push_back( 0.45 );
-    FreeParam.push_back( -0.2 );
+    WidthParam.push_back(1.00);  // Leave fluctuations parameters
+    WidthParam.push_back(1.00);  // fixed for now
+    WidthParam.push_back(0.10);  
+    WidthParam.push_back(0.50);  
+    WidthParam.push_back(0.19);  
+    WidthParam.push_back(2.25);  
+    WidthParam.push_back( 0.0015 ); 
+    WidthParam.push_back( 0.0553 ); 
+    WidthParam.push_back( 0.205 );
+    WidthParam.push_back( 0.45 );
+    WidthParam.push_back( -0.2 );
     
     
   } else {
@@ -177,21 +177,21 @@ int main(int argc, char** argv) {
       no_seed = true;
     }
 
-    FreeParam.clear();
-    NuisParam.clear();
+    WidthParam.clear();
+    YieldParam.clear();
     ERWeightParam.clear();
-    FreeParam.push_back(1.00);  // NR Fi (Fano factor for ionization)
-    FreeParam.push_back(1.00);  // NR Fex
-    FreeParam.push_back(
+    WidthParam.push_back(1.00);  // NR Fi (Fano factor for ionization)
+    WidthParam.push_back(1.00);  // NR Fex
+    WidthParam.push_back(
         0.10);  // amplitude for non-binomial NR recombination fluctuations
-    FreeParam.push_back(0.50);  // center in e-Frac (NR)
-    FreeParam.push_back(0.19);  // width parameter (Gaussian 1-sigma)
-    FreeParam.push_back(2.25);  // raw skewness, for NR
-    FreeParam.push_back( 0.0015 ); //ER Fano normalization for non-density dependence
-    FreeParam.push_back( 0.0553 ); //Minimum amplitude for ER non-binom recomb flucts
-    FreeParam.push_back( 0.205 ); // center in e-frac (ER)
-    FreeParam.push_back( 0.45 );  // width parameter
-    FreeParam.push_back( -0.2 );  // ER non-binom skewness in e-frac
+    WidthParam.push_back(0.50);  // center in e-Frac (NR)
+    WidthParam.push_back(0.19);  // width parameter (Gaussian 1-sigma)
+    WidthParam.push_back(2.25);  // raw skewness, for NR
+    WidthParam.push_back( 0.0015 ); //ER Fano normalization for non-density dependence
+    WidthParam.push_back( 0.0553 ); //Minimum amplitude for ER non-binom recomb flucts
+    WidthParam.push_back( 0.205 ); // center in e-frac (ER)
+    WidthParam.push_back( 0.45 );  // width parameter
+    WidthParam.push_back( -0.2 );  // ER non-binom skewness in e-frac
 
 
     // if (type == "ER") {  // Based on XELDA L-shell 5.2 keV yields
@@ -206,36 +206,36 @@ int main(int argc, char** argv) {
     ERWeightParam.push_back(0.);     // 1.8e-2
      
     if (ValidityTests::nearlyEqual(ATOM_NUM, 18.)) {  // liquid Ar
-      NuisParam.push_back(
+      YieldParam.push_back(
           11.1025);  // +/-1.10 Everything from
                      // https://docs.google.com/document/d/1vLg8vvY5bcdl4Ah4fzyE182DGWt0Wr7_FJ12_B10ujU
-      NuisParam.push_back(1.087399);  // +/-0.025
-      NuisParam.push_back(0.1);       // +/-0.005
-      NuisParam.push_back(-0.0932);   // +/-0.0095
-      NuisParam.push_back(2.998);     // +/-1.026
-      NuisParam.push_back(0.3);       // Fixed
-      NuisParam.push_back(2.94);      // +/-0.12
-      NuisParam.push_back(W_DEFAULT / 1000.);
-      NuisParam.push_back(DBL_MAX);
-      NuisParam.push_back(0.5);  // square root
-      NuisParam.push_back(1.0);
-      NuisParam.push_back(1.0);
+      YieldParam.push_back(1.087399);  // +/-0.025
+      YieldParam.push_back(0.1);       // +/-0.005
+      YieldParam.push_back(-0.0932);   // +/-0.0095
+      YieldParam.push_back(2.998);     // +/-1.026
+      YieldParam.push_back(0.3);       // Fixed
+      YieldParam.push_back(2.94);      // +/-0.12
+      YieldParam.push_back(W_DEFAULT / 1000.);
+      YieldParam.push_back(DBL_MAX);
+      YieldParam.push_back(0.5);  // square root
+      YieldParam.push_back(1.0);
+      YieldParam.push_back(1.0);
     } else {
-      NuisParam.push_back(
+      YieldParam.push_back(
           11.);  // alpha, for NR model. See http://nest.physics.ucdavis.edu
-      NuisParam.push_back(1.1);      // beta
-      NuisParam.push_back(0.0480);   // gamma
-      NuisParam.push_back(-0.0533);  // delta
-      NuisParam.push_back(12.6);     // epsilon
-      NuisParam.push_back(0.3);      // zeta
-      NuisParam.push_back(2.);       // eta
-      NuisParam.push_back(0.3);      // theta
-      NuisParam.push_back(2.);       // iota
+      YieldParam.push_back(1.1);      // beta
+      YieldParam.push_back(0.0480);   // gamma
+      YieldParam.push_back(-0.0533);  // delta
+      YieldParam.push_back(12.6);     // epsilon
+      YieldParam.push_back(0.3);      // zeta
+      YieldParam.push_back(2.);       // eta
+      YieldParam.push_back(0.3);      // theta
+      YieldParam.push_back(2.);       // iota
       // last 3 are the secret extra parameters for additional flexibility
-      NuisParam.push_back(0.5);  // changes sqrt in Qy equation
-      NuisParam.push_back(
+      YieldParam.push_back(0.5);  // changes sqrt in Qy equation
+      YieldParam.push_back(
           1.0);  // makes low-E sigmoid an asymmetric one, for charge
-      NuisParam.push_back(
+      YieldParam.push_back(
           1.0);  // makes low-E sigmoid an asymmetric one, for light
     }
   }
@@ -258,8 +258,8 @@ NESTObservableArray runNESTvec(
   QuantaResult quanta;
   double x, y, z, driftTime, vD;
   RandomGen::rndm()->SetSeed(seed);
-  NuisParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
-  FreeParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
+  YieldParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
+  WidthParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
   vector<double> scint, scint2, wf_amp;
   vector<int64_t> wf_time;
   NESTObservableArray OutputResults;
@@ -279,8 +279,8 @@ NESTObservableArray runNESTvec(
     double smearPos[3] = {x, y, z};  // ignoring the difference in this quick
                                      // function caused by smearing
     result = n.FullCalculation(particleType, eList[i], rho, useField,
-                               detector->get_molarMass(), ATOM_NUM, NuisParam,
-                               FreeParam, verbosity);
+                               detector->get_molarMass(), ATOM_NUM, YieldParam,
+                               WidthParam, verbosity);
     quanta = result.quanta;
     vD = n.SetDriftVelocity(detector->get_T_Kelvin(), rho, useField);
     scint = n.GetS1(quanta, truthPos[0], truthPos[1], truthPos[2], smearPos[0],
@@ -562,11 +562,11 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
   if (type_num == WIMP) {
     yieldsMax =
         n.GetYields(NR, 25.0, rho, centralField, detector->get_molarMass(),
-                    double(atomNum), NuisParam);
+                    double(atomNum), YieldParam);
   } else if (type_num == B8) {
     yieldsMax =
         n.GetYields(NR, 4.00, rho, centralField, detector->get_molarMass(),
-                    double(atomNum), NuisParam);
+                    double(atomNum), YieldParam);
   } else {
     double energyMaximum;
     if (eMax < 0.)
@@ -576,10 +576,10 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
     if ( !energyMaximum || std::isnan(energyMaximum) ) energyMaximum = 1.;
     if (type_num == Kr83m)
       yieldsMax =
-          n.GetYields(Kr83m, eMin, rho, centralField, 400., 100., NuisParam);
+          n.GetYields(Kr83m, eMin, rho, centralField, 400., 100., YieldParam);
     else
       yieldsMax = n.GetYields(type_num, energyMaximum, rho, centralField,
-                              double(massNum), double(atomNum), NuisParam);
+                              double(massNum), double(atomNum), YieldParam);
   }
   if ((g1 * yieldsMax.PhotonYield) > (2. * maxS1) && eMin != eMax &&
       type_num != Kr83m && verbosity && !dEOdxBasis)
@@ -901,23 +901,23 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
       QuantaResult quanta;
       NESTresult result;
       if (dEOdxBasis) {
-	NuisParam[0] = pos_x;
-	NuisParam[1] = pos_y;
-	NuisParam[2] = pos_z;
-	NuisParam[7] = vD_middle;
-	NuisParam[8] = rho;
-	if ( loopNEST ) NuisParam[4] = -TestSpectra::CH3T_spectrum(0.,18.6);
+	YieldParam[0] = pos_x;
+	YieldParam[1] = pos_y;
+	YieldParam[2] = pos_z;
+	YieldParam[7] = vD_middle;
+	YieldParam[8] = rho;
+	if ( loopNEST ) YieldParam[4] = -TestSpectra::CH3T_spectrum(0.,18.6);
 	if ( j == 0 && !loopNEST ) {
-	  NuisParam[3] = eMax;
-	  NuisParam[4] = eMin;
-	  NuisParam[5] = z_step; //5mm for fast, 6um for accurate; .01mm LUXRun3 WS
-	  NuisParam[6] = inField;
-	  NuisParam[9] = 1e3;//MeV
-	  NuisParam[10] = 0.; //+/-1=true, means use continuous slowing-down approx
-	  NuisParam[11] = 0.; //use w/[10] for dE/dx = [10]*keV^[11] e.g. 50 & -0.5
-	  NuisParam[12] = 0.; //fractional variation: e.g .15 = 15%
+	  YieldParam[3] = eMax;
+	  YieldParam[4] = eMin;
+	  YieldParam[5] = z_step; //5mm for fast, 6um for accurate; .01mm LUXRun3 WS
+	  YieldParam[6] = inField;
+	  YieldParam[9] = 1e3;//MeV
+	  YieldParam[10] = 0.; //+/-1=true, means use continuous slowing-down approx
+	  YieldParam[11] = 0.; //use w/[10] for dE/dx = [10]*keV^[11] e.g. 50 & -0.5
+	  YieldParam[12] = 0.; //fractional variation: e.g .15 = 15%
 	}
-	result = n.GetYieldERdEOdxBasis(NuisParam, posiMuon, vTable, ERWeightParam);
+	result = n.GetYieldERdEOdxBasis(YieldParam, posiMuon, vTable, ERWeightParam);
 	yields = result.yields;
 	quanta = result.quanta;
 	if ( ERWeightParam[0] >= 0. )
@@ -942,24 +942,24 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
                       "Xe-129/131m, at low field"
                    << endl;
             }
-            yields = n.GetYieldERWeighted(keV, rho, field, NuisParam);
+            yields = n.GetYieldERWeighted(keV, rho, field, YieldParam);
           } else {
             if (seed < 0 && seed != -1 && type_num <= 5)
               massNum = detector->get_molarMass();
             if (type_num == 11) atomNum = minTimeSeparation;  // Kr83m
             yields = n.GetYields(type_num, keV, rho, field, double(massNum),
-                                 double(atomNum), NuisParam);
+                                 double(atomNum), YieldParam);
           }
           if (type_num == ion) {  // alphas +other nuclei, lighter/heavier than
                                   // medium's default nucleus
-            FreeParam.clear();
-            FreeParam = {
+            WidthParam.clear();
+            WidthParam = {
                 1.00, 1.00, 0.,
                 0.50, 0.19, 0.,
                 0.0015, 0.0553, 
                 0.205, 0.45, -0.2};  // zero out non-binom recomb fluct & skew (NR)
           }
-          if (!dEOdxBasis) quanta = n.GetQuanta(yields, rho, FreeParam);
+          if (!dEOdxBasis) quanta = n.GetQuanta(yields, rho, WidthParam);
         } else {
           yields.PhotonYield = 0.;
           yields.ElectronYield = 0.;
@@ -1010,7 +1010,7 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
                        g2_params);
       if ( dEOdxBasis && !loopNEST ) {
         driftTime = (detector->get_TopDrift() - pos_z) / vD_middle;
-	if ( scint2[7] != -PHE_MIN && FreeParam[0] >= 0. )
+	if ( scint2[7] != -PHE_MIN && WidthParam[0] >= 0. )
 	  scint2[7] *= exp(driftTime / detector->get_eLife_us());
       }
 
@@ -1114,12 +1114,12 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
             keV = (Nph / FudgeFactor[0] + Ne / FudgeFactor[1]) * Wq_eV * 1e-3;
           else {
             if (type_num <= NEST::INTERACTION_TYPE::Cf) {
-              keV = pow((Ne + Nph) / NuisParam[0], 1. / NuisParam[1]);
-              Ne *= 1. - 1. / pow(1. + pow((keV / NuisParam[5]), NuisParam[6]),
-                                  NuisParam[10]);
-              Nph *= 1. - 1. / pow(1. + pow((keV / NuisParam[7]), NuisParam[8]),
-                                   NuisParam[11]);
-              keV = pow((Ne + Nph) / NuisParam[0], 1. / NuisParam[1]);
+              keV = pow((Ne + Nph) / YieldParam[0], 1. / YieldParam[1]);
+              Ne *= 1. - 1. / pow(1. + pow((keV / YieldParam[5]), YieldParam[6]),
+                                  YieldParam[10]);
+              Nph *= 1. - 1. / pow(1. + pow((keV / YieldParam[7]), YieldParam[8]),
+                                   YieldParam[11]);
+              keV = pow((Ne + Nph) / YieldParam[0], 1. / YieldParam[1]);
             } else {
               const double logden = log10(rho);
               const double Wq_eV_alpha =
@@ -1245,9 +1245,9 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
         if (seed < 0 && seed != -1) {  // for when you want means
 	  if (dEOdxBasis) {
 	    if (eMin < 0.)
-	      { yields.PhotonYield = -quanta.photons/NuisParam[4]; yields.ElectronYield = -quanta.electrons/NuisParam[4]; }
+	      { yields.PhotonYield = -quanta.photons/YieldParam[4]; yields.ElectronYield = -quanta.electrons/YieldParam[4]; }
 	    else
-	      { yields.PhotonYield /= NuisParam[10]; yields.ElectronYield /= NuisParam[10]; }
+	      { yields.PhotonYield /= YieldParam[10]; yields.ElectronYield /= YieldParam[10]; }
 	  }
           printf("%.6f\t%.6f\t%.6f\t%.0f, %.0f, %.0f\t%lf\t%lf\t", keV, field,
                  driftTime, smearPos[0], smearPos[1], smearPos[2],


### PR DESCRIPTION
The "FreeParam" vector is primarily used in GetQuanta(...), however it only effects the NR fluctuations models. I've expanded it (to 11 parameters) to include ER fluctuations controls. The additional 5 free parameters were chosen to give similar control over the ER models as what was previously done for NRs.  

In execNEST.cpp, "FreeParam" has various uses, depending on ER, NR, weightedER, dEodx basis (muons), or loopNEST. I've reorganized execNEST.cpp so that FreeParam is always used the same way, regardless of particle type or loopNEST use. To maintain the current dEodx code and weightedER code, I've created another vector with these parameters, called "ERWeightParams". 
 
Attached are sanity checks that functionality of the code is identical. 

Lastly, the "FreeParam" and "NuisParam" vectors have been renamed, to reflect more properly their uses. "FreeParam" is now "ERNRWidthsParam", while "NuisParam" is now "NRYieldsParam". We can decide in a future commit if we want to extend "NRYieldsParam" to include ER Mean Yields Parameters, or if we should have separate vectors for each particle type. 
 
![muon_S1c_test](https://user-images.githubusercontent.com/31666153/166945226-28c477e9-0cca-46c4-9549-18cfe2323d54.png)
![muon_S2c_test](https://user-images.githubusercontent.com/31666153/166945228-3ccf9b72-bafb-42d2-869d-c243591fed27.png)
![neutron_S1c_test](https://user-images.githubusercontent.com/31666153/166945232-a4b5e7ea-b3f7-4697-a258-c1b89090ddbf.png)
![neutron_S2c_test](https://user-images.githubusercontent.com/31666153/166945233-3ccd7e8c-724f-4b74-8f60-a99e2563d90a.png)
![alpha_S1c_test](https://user-images.githubusercontent.com/31666153/166945235-7dd3c956-75c5-43dc-b8b7-97da543e6cfd.png)
![alpha_S2c_test](https://user-images.githubusercontent.com/31666153/166945236-595982cc-9410-44d9-8e4c-03a5e6437190.png)
![beta_S1c_test](https://user-images.githubusercontent.com/31666153/166945237-000f51ee-0438-4ab8-b544-a13d0b968dc7.png)
![beta_S2c_test](https://user-images.githubusercontent.com/31666153/166945238-d274bdf4-53bb-485e-9765-6ca168340023.png)
![ER_S1c_test](https://user-images.githubusercontent.com/31666153/166945240-46030a02-7bcb-4176-98b7-c49ff961522f.png)
![ER_S2c_test](https://user-images.githubusercontent.com/31666153/166945241-16767931-0a1d-4212-b3ab-81d7dd2bc035.png)
![gamma_S1c_test](https://user-images.githubusercontent.com/31666153/166945244-c90c8975-5aee-48fc-b4a9-a6eb517049f8.png)
![gamma_S2c_test](https://user-images.githubusercontent.com/31666153/166945247-307e88f0-64da-4591-83f0-31956cd0eb71.png)

