### PR TITLE
Renamed vector inside dEOdx NEST.cpp function, for readibility. Renam…

### DIFF
--- a/examples/bareNEST.cpp
+++ b/examples/bareNEST.cpp
@@ -183,8 +183,8 @@ int main(int argc, char** argv) {
   // Get yields from NEST calculator, along with number of quanta
   yields = n.GetYields(type_num, keV, rho, field, double(massNum),
                        double(atomNum), NRYieldsParam);
-  vector<double> ERNRWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}; 
-  quanta = n.GetQuanta(yields, rho, ERNRWidthsParam);
+  vector<double> NRERWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}; 
+  quanta = n.GetQuanta(yields, rho, NRERWidthsParam);
 
   // Calculate S2 photons using electron lifetime correction
   double Nphd_S2 =

--- a/include/NEST/NEST.hh
+++ b/include/NEST/NEST.hh
@@ -208,7 +208,7 @@ class NESTcalc {
       default_NRYieldsParam; /* =
                             {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
   static const std::vector<double>
-      default_ERNRWidthsParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
+      default_NRERWidthsParam; /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
 
   NESTresult FullCalculation(
       INTERACTION_TYPE species, double energy, double density, double dfield,
@@ -216,8 +216,8 @@ class NESTcalc {
       const std::vector<double> &NRYieldsParam =
           default_NRYieldsParam, /* =
                                 {11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/
-      const std::vector<double> &ERNRWidthsParam =
-          default_ERNRWidthsParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
+      const std::vector<double> &NRERWidthsParam =
+          default_NRERWidthsParam, /* = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2} */
       bool do_times =
           true);  // the so-called full NEST calculation puts together all the
                   // individual functions/calculations below
@@ -260,10 +260,10 @@ class NESTcalc {
   // Weights beta/gamma models to account for ER sources with differing
   // recombination profiles (such as L-shell electron-capture interactions)
   
-  virtual NESTresult GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsParam,
+  virtual NESTresult GetYieldERdEOdxBasis(const std::vector<double> &dEOdxParam,
 					  string muonInitPos,
 					  vector<double> eDriftVelTable,
-					  const std::vector<double> &ERNRWidthsParam);
+					  const std::vector<double> &NRERWidthsParam);
   // Use dE/dx-based yield models instead of energy-based, as everywhere else
   
   virtual YieldResult GetYieldNR(double energy, double density, double dfield,
@@ -305,7 +305,7 @@ class NESTcalc {
 
   virtual QuantaResult GetQuanta(
       const YieldResult &yields, double density,
-      const std::vector<double> &ERNRWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
+      const std::vector<double> &NRERWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2},
       bool oldModelER = false);
   // GetQuanta takes the yields from above and fluctuates them, both the total
   // quanta (photons+electrons) with a Fano-like factor, and the "slosh" between
@@ -314,18 +314,18 @@ class NESTcalc {
 
   virtual double RecombOmegaNR(
       double elecFrac,
-      const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
+      const std::vector<double> &NRERWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for nuclear recoils and ions (Lindhard<1)
 
   virtual double RecombOmegaER(double efield, double elecFrac,
-                               const std::vector<double> &ERNRWidthsParam,
+                               const std::vector<double> &NRERWidthsParam,
                                bool oldModel = false);
   // Calculates the Omega parameter governing non-binomial recombination
   // fluctuations for gammas and betas (Lindhard==1)
 
   virtual double FanoER(double density, double Nq_mean, double efield,
-      const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
+      const std::vector<double> &NRERWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/);
   // Fano-factor (and Fano-like additional energy resolution model) for gammas
   // and betas (Lindhard==1)
 

--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -20,7 +20,7 @@ bool kr83m_reported_low_deltaT = false;  // to aid in verbosity
 
 const std::vector<double> NESTcalc::default_NRYieldsParam = {
     11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
-const std::vector<double> NESTcalc::default_ERNRWidthsParam = {
+const std::vector<double> NESTcalc::default_NRERWidthsParam = {
     1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
              // Fano factor of ~3 at least for ionization when using
              // OldW13eV (look at first 2 values)
@@ -30,12 +30,12 @@ NESTresult NESTcalc::FullCalculation(
     double A, double Z,
     const std::vector<double>
         &NRYieldsParam /*={11.,1.1,0.0480,-0.0533,12.6,0.3,2.,0.3,2.,0.5,1.,1.}*/,
-    const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
+    const std::vector<double> &NRERWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
     bool do_times /*=true*/) {
   if (density < 1.) fdetector->set_inGas(true);
   NESTresult result;
   result.yields = GetYields(species, energy, density, dfield, A, Z, NRYieldsParam);
-  result.quanta = GetQuanta(result.yields, density, ERNRWidthsParam);
+  result.quanta = GetQuanta(result.yields, density, NRERWidthsParam);
   if (do_times)
     result.photon_times = GetPhotonTimes(
         species, result.quanta.photons, result.quanta.excitons, dfield, energy);
@@ -180,29 +180,29 @@ photonstream NESTcalc::GetPhotonTimes(INTERACTION_TYPE species,
 
 double NESTcalc::RecombOmegaNR(
     double elecFrac,
-    const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/) {
-  double omega = ERNRWidthsParam[2] * exp(-0.5 * pow(elecFrac - ERNRWidthsParam[3], 2.) /
-                                    (ERNRWidthsParam[4] * ERNRWidthsParam[4]));
+    const std::vector<double> &NRERWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/) {
+  double omega = NRERWidthsParam[2] * exp(-0.5 * pow(elecFrac - NRERWidthsParam[3], 2.) /
+                                    (NRERWidthsParam[4] * NRERWidthsParam[4]));
   if (omega < 0.) omega = 0;
   return omega;
 }
 
 double NESTcalc::RecombOmegaER(double efield, double elecFrac,
-                               const std::vector<double> &ERNRWidthsParam,
+                               const std::vector<double> &NRERWidthsParam,
                                bool oldModel) {
   double ampl;
   if (!oldModel)
-    ampl = 0.086036 + (ERNRWidthsParam[7] - 0.086036) / pow(1. + pow(efield / 295.2, 251.6),
+    ampl = 0.086036 + (NRERWidthsParam[7] - 0.086036) / pow(1. + pow(efield / 295.2, 251.6),
                                                 0.0069114);  // NEW(GregR)
-    //ERNRWidthsParam[7] sets the lower-asymptote of field-dependence of ampl
+    //NRERWidthsParam[7] sets the lower-asymptote of field-dependence of ampl
   else
     ampl = 0.14 + (0.043 - 0.14) / (1. + pow(efield / 1210., 1.25));  // OLD
   if (ampl < 0.) ampl = 0.;
-  double wide = ERNRWidthsParam[8];  // Width of omega vs. electron-fraction (i.e. recomb. prob.)
-  double cntr = ERNRWidthsParam[9];  // NEW(GregR) Center of omega vs. elec-frac (OLD value of 0.50 for OLD
+  double wide = NRERWidthsParam[8];  // Width of omega vs. electron-fraction (i.e. recomb. prob.)
+  double cntr = NRERWidthsParam[9];  // NEW(GregR) Center of omega vs. elec-frac (OLD value of 0.50 for OLD
                        // ampl above 0.14...)
   if (oldModel) cntr = 0.50;
-  double skew = ERNRWidthsParam[10];  // Skewness of omega vs. elec-frac distribution
+  double skew = NRERWidthsParam[10];  // Skewness of omega vs. elec-frac distribution
   double mode = cntr + 2. * inv_sqrt2_PI * skew * wide / sqrt(1. + skew * skew);
   double norm =
       1. / (exp(-0.5 * pow(mode - cntr, 2.) / (wide * wide)) *
@@ -216,7 +216,7 @@ double NESTcalc::RecombOmegaER(double efield, double elecFrac,
 }
 
 double NESTcalc::FanoER(double density, double Nq_mean, double efield,
-                       const std::vector<double> &ERNRWidthsParam) {
+                       const std::vector<double> &NRERWidthsParam) {
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))  // liquid argon
     return 0.1115;  // T&I. conflicting reports of .107 (Doke) & ~0.1 elsewhere
   double Fano =
@@ -228,19 +228,19 @@ double NESTcalc::FanoER(double density, double Nq_mean, double efield,
           pow(density,
               3.);  // to get it to be ~0.03 for LXe (E Dahl Ph.D. thesis)
   if (!fdetector->get_inGas())
-    Fano += ERNRWidthsParam[6] * sqrt(Nq_mean) * pow(efield, 0.5);
+    Fano += NRERWidthsParam[6] * sqrt(Nq_mean) * pow(efield, 0.5);
   return Fano;
 }
 
 QuantaResult NESTcalc::GetQuanta(
     const YieldResult &yields, double density,
-    const std::vector<double> &ERNRWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
+    const std::vector<double> &NRERWidthsParam /*={1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2}*/,
     bool oldModelER) {
   QuantaResult result{};
   bool HighE;
   int Nq_actual, Ne, Nph, Ni, Nex;
 
-  if (ERNRWidthsParam.size() < 11) {
+  if (NRERWidthsParam.size() < 11) {
     throw std::runtime_error(
         "ERROR: You need a minimum of 11 free parameters for the resolution "
         "model.");
@@ -265,7 +265,7 @@ QuantaResult NESTcalc::GetQuanta(
   }
 
   if (ValidityTests::nearlyEqual(yields.Lindhard, 1.)) {
-    double Fano = FanoER(density, Nq_mean, yields.ElectricField, ERNRWidthsParam);
+    double Fano = FanoER(density, Nq_mean, yields.ElectricField, NRERWidthsParam);
     Nq_actual = int(floor(
         RandomGen::rndm()->rand_gauss(Nq_mean, sqrt(Fano * Nq_mean)) + 0.5));
     if (Nq_actual < 0 || ValidityTests::nearlyEqual(Nq_mean, 0.)) Nq_actual = 0;
@@ -274,12 +274,12 @@ QuantaResult NESTcalc::GetQuanta(
     Nex = Nq_actual - Ni;
 
   } else {
-    double Fano = ERNRWidthsParam[0];
+    double Fano = NRERWidthsParam[0];
     Ni = int(floor(RandomGen::rndm()->rand_gauss(Nq_mean * alf,
                                                  sqrt(Fano * Nq_mean * alf)) +
                    0.5));
     if (Ni < 0) Ni = 0;
-    Fano = ERNRWidthsParam[1];
+    Fano = NRERWidthsParam[1];
     Nex = int(floor(RandomGen::rndm()->rand_gauss(
                         Nq_mean * excitonRatio * alf,
                         sqrt(Fano * Nq_mean * excitonRatio * alf)) +
@@ -321,8 +321,8 @@ QuantaResult NESTcalc::GetQuanta(
   // set omega (non-binomial recombination fluctuations parameter) according to
   // whether the Lindhard <1, i.e. this is NR.
   double omega = yields.Lindhard < 1
-                     ? RecombOmegaNR(elecFrac, ERNRWidthsParam)
-                     : RecombOmegaER(yields.ElectricField, elecFrac, ERNRWidthsParam,
+                     ? RecombOmegaNR(elecFrac, NRERWidthsParam)
+                     : RecombOmegaER(yields.ElectricField, elecFrac, NRERWidthsParam,
                                      oldModelER);
   if (ValidityTests::nearlyEqual(ATOM_NUM, 18.))
     omega = 0.0;  // Ar has no non-binom sauce
@@ -358,7 +358,7 @@ QuantaResult NESTcalc::GetQuanta(
                      exp(-1. * engy / E1) * exp(-1. * sqrt(fld) / sqrt(F1));
       // if ( std::abs(skewness) <= DBL_MIN ) skewness = DBL_MIN;
     } else {
-      skewness = ERNRWidthsParam[5];  // 2.25 but ~5-20 also good (for NR). All better
+      skewness = NRERWidthsParam[5];  // 2.25 but ~5-20 also good (for NR). All better
                                 // than zero, but 0 is OK too
     }  // note to self: find way to make 0 for ion (wall BG) incl. alphas?
   }
@@ -468,24 +468,24 @@ YieldResult NESTcalc::GetYieldERWeighted(double energy, double density,
   return YieldResultValidity(result, energy, Wq_eV);
 }
 
-NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsParam,
+NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &dEOdxParam,
 					  string muonInitPos,
 					  vector<double> vTable,
-					  const std::vector<double> &ERNRWidthsParam) {
-  Wvalue wvalue = WorkFunction(NRYieldsParam[8], fdetector->get_molarMass(),
+					  const std::vector<double> &NRERWidthsParam) {
+  Wvalue wvalue = WorkFunction(dEOdxParam[8], fdetector->get_molarMass(),
                                fdetector->get_OldW13eV());
-  double Wq_eV = wvalue.Wq_eV; double rho = NRYieldsParam[8];
+  double Wq_eV = wvalue.Wq_eV; double rho = dEOdxParam[8];
   double xi = -999., yi = -999., zi = fdetector->get_TopDrift();
   double xf, yf, zf, pos_x, pos_y, pos_z, r, phi, field,
-    eMin = NRYieldsParam[4], z_step = NRYieldsParam[5], inField = NRYieldsParam[6];
+    eMin = dEOdxParam[4], z_step = dEOdxParam[5], inField = dEOdxParam[6];
   if(ValidityTests::nearlyEqual(eMin, 0.) || std::isnan(eMin))
     throw std::runtime_error("Energy cannot be zero or undefined");
   NESTresult result{};
-  xf = NRYieldsParam[0];
-  yf = NRYieldsParam[1];
-  zf = NRYieldsParam[2];
-  if (ValidityTests::nearlyEqual(NRYieldsParam[3], -1.)) {
-    if ( ERNRWidthsParam[0] < 0. && eMin < 0. ) {
+  xf = dEOdxParam[0];
+  yf = dEOdxParam[1];
+  zf = dEOdxParam[2];
+  if (ValidityTests::nearlyEqual(dEOdxParam[3], -1.)) {
+    if ( NRERWidthsParam[0] < 0. && eMin < 0. ) {
       xi = xf - 10.;
       yi = yf;
       zi = zf;
@@ -516,16 +516,16 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsPar
   double dEOdx, eStep, refEnergy;
   if (eMin < 0.) {
     refEnergy = -eMin;
-    if ( NRYieldsParam[10] > 0. && NRYieldsParam[11] != 0. ) {
-      dEOdx = NRYieldsParam[10]*pow(-eMin,NRYieldsParam[11]);
-      if ( NRYieldsParam[12] > 0. )
-	dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,NRYieldsParam[12]*dEOdx,true);
+    if ( dEOdxParam[10] > 0. && dEOdxParam[11] != 0. ) {
+      dEOdx = dEOdxParam[10]*pow(-eMin,dEOdxParam[11]);
+      if ( dEOdxParam[12] > 0. )
+	dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,dEOdxParam[12]*dEOdx,true);
     }
     else
-      dEOdx = CalcElectronLET(-eMin, ATOM_NUM, NRYieldsParam[10]);
+      dEOdx = CalcElectronLET(-eMin, ATOM_NUM, dEOdxParam[10]);
     eStep =dEOdx * rho * z_step * 1e2;
   } else {
-    refEnergy = NRYieldsParam[9];
+    refEnergy = dEOdxParam[9];
     eStep = eMin * rho * z_step * 1e2;
   }
   double driftTime, vD, keV = 0., Nq_mean;
@@ -552,38 +552,38 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsPar
     else field = inField;
     if (eMin < 0.) {
       if ((keV + eStep) > -eMin) eStep = -eMin - keV;
-      if ( ERNRWidthsParam[0] < 0. ) {
-	YieldResult yields{}; Nq_mean = -ERNRWidthsParam[0] * eStep;
-	double Ni_mean = Nq_mean/(1.+ERNRWidthsParam[1]); xi_tib = Ni_mean*(ERNRWidthsParam[3]/4.)*pow(eStep,ERNRWidthsParam[4]-1.);
-	yields.PhotonYield = Ni_mean * (1.+ERNRWidthsParam[1]-log(ERNRWidthsParam[2]+xi_tib)/xi_tib);
+      if ( NRERWidthsParam[0] < 0. ) {
+	YieldResult yields{}; Nq_mean = -NRERWidthsParam[0] * eStep;
+	double Ni_mean = Nq_mean/(1.+NRERWidthsParam[1]); xi_tib = Ni_mean*(NRERWidthsParam[3]/4.)*pow(eStep,NRERWidthsParam[4]-1.);
+	yields.PhotonYield = Ni_mean * (1.+NRERWidthsParam[1]-log(NRERWidthsParam[2]+xi_tib)/xi_tib);
 	yields.ElectronYield = Nq_mean - yields.PhotonYield;
-	yields.ExcitonRatio = ERNRWidthsParam[1]; yields.Lindhard = 1.;
+	yields.ExcitonRatio = NRERWidthsParam[1]; yields.Lindhard = 1.;
 	yields.ElectricField = field; yields.DeltaT_Scint = -999; result.yields = yields;
       }
       else
-	result.yields = GetYieldBetaGR(eStep, rho, field, NRYieldsParam);
+	result.yields = GetYieldBetaGR(eStep, rho, field, default_NRYieldsParam);
     } else
-      result.yields = GetYieldBetaGR(refEnergy, rho, field, NRYieldsParam);
-    if ( eMin < 0. && ERNRWidthsParam[0] < 0. ) {
+      result.yields = GetYieldBetaGR(refEnergy, rho, field, default_NRYieldsParam);
+    if ( eMin < 0. && NRERWidthsParam[0] < 0. ) {
       QuantaResult quanta{};
       if ( Nq_mean < 1. ) Nq = 0;
-      else Nq = int(ceil(RandomGen::rndm()->rand_gauss(Nq_mean,sqrt(ERNRWidthsParam[5]*Nq_mean),true)-0.5));
+      else Nq = int(ceil(RandomGen::rndm()->rand_gauss(Nq_mean,sqrt(NRERWidthsParam[5]*Nq_mean),true)-0.5));
       if ( result.yields.PhotonYield < 1. || Nq <= 0 ) quanta.photons = 0;
-      else quanta.photons = int(ceil(RandomGen::rndm()->rand_gauss(result.yields.PhotonYield,sqrt(ERNRWidthsParam[6]*result.yields.PhotonYield),true)-0.5));
+      else quanta.photons = int(ceil(RandomGen::rndm()->rand_gauss(result.yields.PhotonYield,sqrt(NRERWidthsParam[6]*result.yields.PhotonYield),true)-0.5));
       quanta.electrons = Nq - quanta.photons;
-      quanta.ions = int(ceil(double(Nq)/(1.+ERNRWidthsParam[1])-0.5));
+      quanta.ions = int(ceil(double(Nq)/(1.+NRERWidthsParam[1])-0.5));
       quanta.excitons = Nq - quanta.ions;
-      quanta.recombProb = 1. - log ( ERNRWidthsParam[2] + xi_tib ) / xi_tib;
-      quanta.Variance = ERNRWidthsParam[6] * result.yields.PhotonYield;
+      quanta.recombProb = 1. - log ( NRERWidthsParam[2] + xi_tib ) / xi_tib;
+      quanta.Variance = NRERWidthsParam[6] * result.yields.PhotonYield;
       result.quanta = quanta;
       Ne += result.quanta.electrons;
     }
     else
-      result.quanta = GetQuanta(result.yields, rho, default_ERNRWidthsParam, true);
+      result.quanta = GetQuanta(result.yields, rho, default_NRERWidthsParam, true);
     if (eMin > 0.)
       Nph += result.quanta.photons * (eStep / refEnergy);
     else {
-      if ( ERNRWidthsParam[0] >= 0. ) {
+      if ( NRERWidthsParam[0] >= 0. ) {
 	Nq = result.quanta.photons + result.quanta.electrons;
 	double FanoOverall = 0.0015 * sqrt((-1e3*eMin/Wq_eV)*field);
 	double FanoScint = 20. * FanoOverall;
@@ -597,11 +597,11 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsPar
     int index = int(floor(zz / z_step + 0.5));
     if (index >= vTable.size()) index = vTable.size() - 1;
     if (vTable.size() == 0)
-      vD = NRYieldsParam[7];
+      vD = dEOdxParam[7];
     else
       vD = vTable[index];
     driftTime = (fdetector->get_TopDrift() - zz) / vD;
-    if ( zz >= fdetector->get_cathode() && ERNRWidthsParam[0] >= 0. ) {
+    if ( zz >= fdetector->get_cathode() && NRERWidthsParam[0] >= 0. ) {
       if (eMin > 0.)
 	Ne += result.quanta.electrons * (eStep / refEnergy) * exp(-driftTime / fdetector->get_eLife_us());
       else
@@ -614,13 +614,13 @@ NESTresult NESTcalc::GetYieldERdEOdxBasis(const std::vector<double> &NRYieldsPar
     zz += norm[2] * z_step;
     if (eMin < 0.) {
       refEnergy -= eStep;
-      if ( NRYieldsParam[10] > 0. && NRYieldsParam[11] != 0. ) {
-	dEOdx = NRYieldsParam[10]*pow(refEnergy,NRYieldsParam[11]);
-	if ( NRYieldsParam[12] > 0. )
-	  dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,NRYieldsParam[12]*dEOdx,true);
+      if ( dEOdxParam[10] > 0. && dEOdxParam[11] != 0. ) {
+	dEOdx = dEOdxParam[10]*pow(refEnergy,dEOdxParam[11]);
+	if ( dEOdxParam[12] > 0. )
+	  dEOdx = RandomGen::rndm()->rand_gauss(dEOdx,dEOdxParam[12]*dEOdx,true);
       }
       else
-	dEOdx = CalcElectronLET(refEnergy, ATOM_NUM, NRYieldsParam[10]);
+	dEOdx = CalcElectronLET(refEnergy, ATOM_NUM, dEOdxParam[10]);
       eStep = dEOdx * rho * z_step * 1e2;
     }
     // cerr << keV << "\t\t" << xx << "\t" << yy << "\t" << zz << "\t" << Nph << "\t" << Ne << endl;
@@ -1063,10 +1063,6 @@ YieldResult  // NEW
 NESTcalc::GetYieldBetaGR(double energy, double density, double dfield,
                          const std::vector<double> &NRYieldsParam) {
   bool oldModelER = false;
-  /*if (RecombOmegaER(0.0, 0.5, NRYieldsParam, oldModelER) < 0.05)
-    cerr << "WARNING! You need to change RecombOmegaER to go along with "
-            "GetYieldBetaGR"
-         << endl;*/
 
   Wvalue wvalue = WorkFunction(density, fdetector->get_molarMass(),
                                fdetector->get_OldW13eV());

--- a/src/execNEST.cpp
+++ b/src/execNEST.cpp
@@ -27,7 +27,7 @@
 using namespace std;
 using namespace NEST;
 
-vector<double> ERNRWidthsParam, NRYieldsParam, ERWeightParam;
+vector<double> NRERWidthsParam, NRYieldsParam, ERWeightParam;
 double band[NUMBINS_MAX][7], energies[3],
     AnnModERange[2] = {1.5, 6.5};  // keVee or nr (recon)
 bool BeenHere = false;
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
     fPos = -1.;
     seed = 0;
     no_seed = false;
-    ERNRWidthsParam.clear();
+    NRERWidthsParam.clear();
     NRYieldsParam.clear();
     ERWeightParam.clear();
     verbosity = false;
@@ -140,17 +140,17 @@ int main(int argc, char** argv) {
     ERWeightParam.push_back(atof(argv[10]));
     ERWeightParam.push_back(atof(argv[11]));
 
-    ERNRWidthsParam.push_back(1.00);  // Leave fluctuations parameters
-    ERNRWidthsParam.push_back(1.00);  // fixed for now
-    ERNRWidthsParam.push_back(0.10);  
-    ERNRWidthsParam.push_back(0.50);  
-    ERNRWidthsParam.push_back(0.19);  
-    ERNRWidthsParam.push_back(2.25);  
-    ERNRWidthsParam.push_back( 0.0015 ); 
-    ERNRWidthsParam.push_back( 0.0553 ); 
-    ERNRWidthsParam.push_back( 0.205 );
-    ERNRWidthsParam.push_back( 0.45 );
-    ERNRWidthsParam.push_back( -0.2 );
+    NRERWidthsParam.push_back(1.00);  // Leave fluctuations parameters
+    NRERWidthsParam.push_back(1.00);  // fixed for now
+    NRERWidthsParam.push_back(0.10);  
+    NRERWidthsParam.push_back(0.50);  
+    NRERWidthsParam.push_back(0.19);  
+    NRERWidthsParam.push_back(2.25);  
+    NRERWidthsParam.push_back( 0.0015 ); 
+    NRERWidthsParam.push_back( 0.0553 ); 
+    NRERWidthsParam.push_back( 0.205 );
+    NRERWidthsParam.push_back( 0.45 );
+    NRERWidthsParam.push_back( -0.2 );
     
     
   } else {
@@ -177,21 +177,21 @@ int main(int argc, char** argv) {
       no_seed = true;
     }
 
-    ERNRWidthsParam.clear();
+    NRERWidthsParam.clear();
     NRYieldsParam.clear();
     ERWeightParam.clear();
-    ERNRWidthsParam.push_back(1.00);  // NR Fi (Fano factor for ionization)
-    ERNRWidthsParam.push_back(1.00);  // NR Fex
-    ERNRWidthsParam.push_back(
+    NRERWidthsParam.push_back(1.00);  // NR Fi (Fano factor for ionization)
+    NRERWidthsParam.push_back(1.00);  // NR Fex
+    NRERWidthsParam.push_back(
         0.10);  // amplitude for non-binomial NR recombination fluctuations
-    ERNRWidthsParam.push_back(0.50);  // center in e-Frac (NR)
-    ERNRWidthsParam.push_back(0.19);  // width parameter (Gaussian 1-sigma)
-    ERNRWidthsParam.push_back(2.25);  // raw skewness, for NR
-    ERNRWidthsParam.push_back( 0.0015 ); //ER Fano normalization for non-density dependence
-    ERNRWidthsParam.push_back( 0.0553 ); //Minimum amplitude for ER non-binom recomb flucts
-    ERNRWidthsParam.push_back( 0.205 ); // center in e-frac (ER)
-    ERNRWidthsParam.push_back( 0.45 );  // width parameter
-    ERNRWidthsParam.push_back( -0.2 );  // ER non-binom skewness in e-frac
+    NRERWidthsParam.push_back(0.50);  // center in e-Frac (NR)
+    NRERWidthsParam.push_back(0.19);  // width parameter (Gaussian 1-sigma)
+    NRERWidthsParam.push_back(2.25);  // raw skewness, for NR
+    NRERWidthsParam.push_back( 0.0015 ); //ER Fano normalization for non-density dependence
+    NRERWidthsParam.push_back( 0.0553 ); //Minimum amplitude for ER non-binom recomb flucts
+    NRERWidthsParam.push_back( 0.205 ); // center in e-frac (ER)
+    NRERWidthsParam.push_back( 0.45 );  // width parameter
+    NRERWidthsParam.push_back( -0.2 );  // ER non-binom skewness in e-frac
 
 
     // if (type == "ER") {  // Based on XELDA L-shell 5.2 keV yields
@@ -259,7 +259,7 @@ NESTObservableArray runNESTvec(
   double x, y, z, driftTime, vD;
   RandomGen::rndm()->SetSeed(seed);
   NRYieldsParam = {11., 1.1, 0.0480, -0.0533, 12.6, 0.3, 2., 0.3, 2., 0.5, 1., 1.};
-  ERNRWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
+  NRERWidthsParam = {1.,1.,0.1,0.5,0.19,2.25, 0.0015, 0.0553, 0.205, 0.45, -0.2};
   vector<double> scint, scint2, wf_amp;
   vector<int64_t> wf_time;
   NESTObservableArray OutputResults;
@@ -280,7 +280,7 @@ NESTObservableArray runNESTvec(
                                      // function caused by smearing
     result = n.FullCalculation(particleType, eList[i], rho, useField,
                                detector->get_molarMass(), ATOM_NUM, NRYieldsParam,
-                               ERNRWidthsParam, verbosity);
+                               NRERWidthsParam, verbosity);
     quanta = result.quanta;
     vD = n.SetDriftVelocity(detector->get_T_Kelvin(), rho, useField);
     scint = n.GetS1(quanta, truthPos[0], truthPos[1], truthPos[2], smearPos[0],
@@ -952,14 +952,14 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
           }
           if (type_num == ion) {  // alphas +other nuclei, lighter/heavier than
                                   // medium's default nucleus
-            ERNRWidthsParam.clear();
-            ERNRWidthsParam = {
+            NRERWidthsParam.clear();
+            NRERWidthsParam = {
                 1.00, 1.00, 0.,
                 0.50, 0.19, 0.,
                 0.0015, 0.0553, 
                 0.205, 0.45, -0.2};  // zero out non-binom recomb fluct & skew (NR)
           }
-          if (!dEOdxBasis) quanta = n.GetQuanta(yields, rho, ERNRWidthsParam);
+          if (!dEOdxBasis) quanta = n.GetQuanta(yields, rho, NRERWidthsParam);
         } else {
           yields.PhotonYield = 0.;
           yields.ElectronYield = 0.;
@@ -1010,7 +1010,7 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
                        g2_params);
       if ( dEOdxBasis && !loopNEST ) {
         driftTime = (detector->get_TopDrift() - pos_z) / vD_middle;
-	if ( scint2[7] != -PHE_MIN && ERNRWidthsParam[0] >= 0. )
+	if ( scint2[7] != -PHE_MIN && NRERWidthsParam[0] >= 0. )
 	  scint2[7] *= exp(driftTime / detector->get_eLife_us());
       }
 


### PR DESCRIPTION
…ed width vector to 'NRERWidthsParam' since NRs are listed first. Removed old comment on GetYieldBetaGR