### PR TITLE
Rename variable following NEST class restyling

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -133,7 +133,7 @@ void NESTProc::TryPopLineages(const G4Track& aTrack, const G4Step& aStep) {
           fDetector->FitEF(maxHit_xyz.x(), maxHit_xyz.y(), maxHit_xyz.z());
       lineage.result = fNESTcalc->FullCalculation(
           lineage.type, etot, lineage.density, efield_here, lineage.A,
-          lineage.Z, NESTcalc::default_NuisParam, NESTcalc::default_FreeParam,
+          lineage.Z, NESTcalc::default_NRYieldsParam, NESTcalc::default_NRERWidthsParam,
           detailed_secondaries);
       lineage.result_calculated = true;
       if (lineage.result.quanta.photons) {


### PR DESCRIPTION
One of the latest change of variable names in the `NEST.cpp` files was not propagated in the G4 integration code and the code didn't compile. This PR fixes the issue.