### PR TITLE
LArNEST fluctuations.

### DIFF
--- a/examples/LArNEST/CMakeLists.txt
+++ b/examples/LArNEST/CMakeLists.txt
@@ -4,8 +4,11 @@
 add_executable(LegacyLArNESTBenchmarks LegacyLArNESTBenchmarks.cpp)
 target_link_libraries(LegacyLArNESTBenchmarks PUBLIC NEST::Core)
 
-add_executable(LArNESTBenchmarks LArNESTBenchmarks.cpp)
-target_link_libraries(LArNESTBenchmarks PUBLIC NEST::Core)
+add_executable(LArNESTMeanYieldsBenchmarks LArNESTMeanYieldsBenchmarks.cpp)
+target_link_libraries(LArNESTMeanYieldsBenchmarks PUBLIC NEST::Core)
+
+add_executable(LArNESTFluctuationBenchmarks LArNESTFluctuationBenchmarks.cpp)
+target_link_libraries(LArNESTFluctuationBenchmarks PUBLIC NEST::Core)
 
 add_executable(LArNESTNeutronCapture LArNESTNeutronCapture.cpp)
 target_link_libraries(LArNESTNeutronCapture PUBLIC NEST::Core)

--- a/examples/LArNEST/CMakeLists.txt
+++ b/examples/LArNEST/CMakeLists.txt
@@ -6,3 +6,6 @@ target_link_libraries(LegacyLArNESTBenchmarks PUBLIC NEST::Core)
 
 add_executable(LArNESTBenchmarks LArNESTBenchmarks.cpp)
 target_link_libraries(LArNESTBenchmarks PUBLIC NEST::Core)
+
+add_executable(LArNESTNeutronCapture LArNESTNeutronCapture.cpp)
+target_link_libraries(LArNESTNeutronCapture PUBLIC NEST::Core)

--- a/examples/LArNEST/LArNESTFluctuationBenchmarks.cpp
+++ b/examples/LArNEST/LArNESTFluctuationBenchmarks.cpp
@@ -1,0 +1,173 @@
+/**
+ * @file legacyLArNEST.cpp
+ * @author NEST Collaboration
+ * @author Nicholas Carrara [nmcarrara@ucdavis.edu]
+ * @brief Benchmarks for LAr ER model.  This program generates ...
+ * @version 
+ * @date 2022-04-14
+ */
+#include <fstream>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+
+#include "LArDetector.hh"
+#include "LArNEST.hh"
+
+int main(int argc, char* argv[])
+{
+    // this sample program takes can take two arguments,
+    // (optional) 1) density - the density of the LAr to use
+    // (optional) 2) seed - a seed for the random number generator
+
+    double density = 1.393;
+    uint64_t seed = 0;
+    uint64_t num_events = 100;
+    if (argc > 1) {
+        density = atof(argv[1]);
+    }
+    if (argc > 2) {
+        seed = atoi(argv[2]);
+    }
+    if (argc > 3) {
+        num_events = atoi(argv[3]);
+    }
+
+    // set up energy steps
+    int num_energy_steps = 50000;
+    std::vector<double> energy_vals; 
+    double start_val = .1;
+    double end_val = 1000;
+    double step_size = (end_val - start_val)/num_energy_steps;
+
+    for (size_t i = 0; i < num_energy_steps; i++)
+    {
+        energy_vals.emplace_back(start_val + step_size * i);
+    }
+    std::vector<NEST::LArInteraction> particle_types = {
+        NEST::LArInteraction::NR, NEST::LArInteraction::ER, NEST::LArInteraction::Alpha
+    };
+    std::vector<std::string> particle_type = {
+        "NR", "ER", "Alpha"
+    };
+
+    LArDetector* detector = new LArDetector();
+    // Construct NEST class using detector object
+    NEST::LArNEST larnest(detector);
+    // Set random seed of RandomGen class
+    RandomGen::rndm()->SetSeed(seed);
+
+    // Construct NEST objects for storing calculation results
+    NEST::LArNESTResult result;
+    std::ofstream output_file;
+
+    output_file.open("fluctuation_benchmarks.csv");
+    output_file << "type,energy,efield,TotalYield,QuantaYield,LightYield,Nph,Ne,Nex,Nion,TotalYield_std,QuantaYield_std,LightYield_std,Nph_std,Ne_std,Nex_std,Nion_std\n";
+
+    // iterate over electric field values
+    for (size_t k = 0; k < particle_types.size(); k++)
+    {
+        std::vector<double> electric_field;
+        if (particle_types[k] == NEST::LArInteraction::NR)
+        {
+            electric_field.insert(electric_field.end(), {
+                1, 50, 100, 200, 250, 500, 1000, 1500, 1750, 2000
+            });
+        }
+        else if (particle_types[k] == NEST::LArInteraction::ER)
+        {
+            electric_field.insert(electric_field.end(), {
+                1, 100, 200, 600, 1000, 1500, 2500, 6000, 9000, 9500
+            });
+        }
+        else
+        {
+            electric_field.insert(electric_field.end(), {
+                1, 50, 100, 500, 1000, 5000, 10000, 20000
+            });
+        }            
+        // iterate over number of events
+        for (size_t v = 0; v < electric_field.size(); v++)
+        {
+            for (size_t i = 0; i < num_energy_steps; i++)
+            {
+                std::vector<double> Nph(num_events);
+                std::vector<double> Ne(num_events);
+                std::vector<double> Nex(num_events);
+                std::vector<double> Nion(num_events);
+                // collect statistics for each event
+                for (size_t j = 0; j < num_events; j++)
+                {
+                    result = larnest.FullCalculation(
+                        particle_types[k],
+                        energy_vals[i],
+                        electric_field[v],
+                        density,
+                        false
+                    );
+                    Nph[j] = double(result.fluctuations.NphFluctuation);                
+                    Ne[j] = double(result.fluctuations.NeFluctuation);
+                    Nex[j] = double(result.fluctuations.NexFluctuation);
+                    Nion[j] = double(result.fluctuations.NionFluctuation);
+                }
+                double Nph_mean = std::accumulate(Nph.begin(), Nph.end(), 0.0) / double(num_events);
+                double Ne_mean = std::accumulate(Ne.begin(), Ne.end(), 0.0) / double(num_events);
+                double Nex_mean = std::accumulate(Nex.begin(), Nex.end(), 0.0) / double(num_events);
+                double Nion_mean = std::accumulate(Nion.begin(), Nion.end(), 0.0) / double(num_events);
+
+                double Nq_mean = Nph_mean + Ne_mean;
+                double Nq_std = 0.0;
+                double Nph_std = 0.0;
+                double Ne_std = 0.0;
+                double Nex_std = 0.0;
+                double Nion_std = 0.0;
+
+                for (size_t ii = 0; ii < Nph.size(); ii++) {
+                    Nq_std += (Nph[ii] + Ne[ii] - Nq_mean) * (Nph[ii] + Ne[ii] - Nq_mean);
+                }
+                Nq_std = std::sqrt(Nq_std / double(num_events));
+
+                for (size_t ii = 0; ii < Nph.size(); ii++) {
+                    Nph_std += (Nph[ii] - Nph_mean) * (Nph[ii] - Nph_mean);
+                }
+                Nph_std = std::sqrt(Nph_std / double(num_events));
+
+                for (size_t ii = 0; ii < Ne.size(); ii++) {
+                    Ne_std += (Ne[ii] - Ne_mean) * (Ne[ii] - Ne_mean);
+                }
+                Ne_std = std::sqrt(Ne_std / double(num_events));
+
+                for (size_t ii = 0; ii < Nex.size(); ii++) {
+                    Nex_std += (Nex[ii] - Nex_mean) * (Nex[ii] - Nex_mean);
+                }
+                Nex_std = std::sqrt(Nex_std / double(num_events));
+
+                for (size_t ii = 0; ii < Nion.size(); ii++) {
+                    Nion_std += (Nion[ii] - Nion_mean) * (Nion[ii] - Nion_mean);
+                }
+                Nion_std = std::sqrt(Nion_std / double(num_events));
+
+                output_file << particle_type[k] << ",";
+                output_file << energy_vals[i] << ","; 
+                output_file << electric_field[v] << ",";
+                output_file << (Nq_mean / energy_vals[i]) << ",";
+                output_file << (Ne_mean / energy_vals[i]) << ",";
+                output_file << (Nph_mean / energy_vals[i]) << ",";
+                output_file << Nph_mean << ",";
+                output_file << Ne_mean << ",";
+                output_file << Nex_mean << ",";
+                output_file << Nion_mean << ",";
+                output_file << (Nq_std / energy_vals[i]) << ",";
+                output_file << (Ne_std / energy_vals[i]) << ",";
+                output_file << (Nph_std / energy_vals[i]) << ",";
+                output_file << Nph_std << ",";
+                output_file << Ne_std << ",";
+                output_file << Nex_std << ",";
+                output_file << Nion_std << "\n";
+            }
+        }
+    }
+    output_file.close();
+    return 0;
+}

--- a/examples/LArNEST/LArNESTMeanYieldsBenchmarks.cpp
+++ b/examples/LArNEST/LArNESTMeanYieldsBenchmarks.cpp
@@ -58,8 +58,8 @@ int main(int argc, char* argv[])
     NEST::LArNESTResult result;
     std::ofstream output_file;
 
-    output_file.open("benchmarks.csv");
-    output_file << "type,energy,efield,TotalYield,QuantaYield,LightYield,Nph,Ne,Nex,Nion\n";
+    output_file.open("mean_yields_benchmarks.csv");
+    output_file << "type,energy,efield,TotalYield,QuantaYield,LightYield,Nph,Ne,Nex,Nion,TotalYield_std,QuantaYield_std,LightYield_std,Nph_std,Ne_std,Nex_std,Nion_std\n";
 
     // iterate over electric field values
     for (size_t k = 0; k < particle_types.size(); k++)
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
                 output_file << result.yields.Nph << ",";
                 output_file << result.yields.Ne << ",";
                 output_file << result.yields.Nex << ",";
-                output_file << result.yields.Nion << "\n";
+                output_file << result.yields.Nion << ",0,0,0,0,0,0,0\n";
             }
         }
     }

--- a/examples/LArNEST/LArNESTNeutronCapture.cpp
+++ b/examples/LArNEST/LArNESTNeutronCapture.cpp
@@ -1,0 +1,84 @@
+/**
+ * @file LArNESTNeutronCapture.cpp
+ * @author Nicholas Carrara [nmcarrara@ucdavis.edu]
+ * @brief 
+ * @version 0.1
+ * @date 2022-05-23
+ */
+#include <fstream>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+
+#include "LArDetector.hh"
+#include "LArNEST.hh"
+
+int main(int argc, char* argv[])
+{
+    double density = 1.393;
+    uint64_t seed = 0;
+    if (argc > 1) {
+        density = atof(argv[1]);
+    }
+    if (argc > 2) {
+        seed = atoi(argv[2]);
+    }
+
+    std::vector<double> electric_field = {
+        1, 100, 200, 500, 600, 1000, 1500, 2500, 6000, 9000, 9500
+    };
+
+    std::vector<double> energy_vals = {
+        167.3, 516.0, 348.7, 867.3, 837.7, 1186.8, 1354.0,
+        1044.3, 1881.5, 2229.5, 2566.1, 2432.5, 2781.8,
+        2842.5, 3111.3, 1972.6, 2291.6, 2810.5, 
+        3564.7, 3405.5, 2668.1, 3564.5, 2614.3,
+        3451.8, 4102.5,
+        1828.8, 2130.7, 2668.1, 2771.8, 3089.4, 3150.2, 
+        3365.5, 3405.3, 3700.4, 4745.0, 5063.7, 5582.0,
+        6098.9
+    };
+    
+    LArDetector* detector = new LArDetector();
+    // Construct NEST class using detector object
+    NEST::LArNEST larnest(detector);
+    // Set random seed of RandomGen class
+    RandomGen::rndm()->SetSeed(seed);
+
+    // Construct NEST objects for storing calculation results
+    NEST::LArNESTResult result;
+    std::ofstream output_file;
+
+    output_file.open("neutron_capture.csv");
+    output_file << "type,energy,efield,TotalYield,QuantaYield,LightYield,Nph,Ne,Nex,Nion\n";
+
+    for (size_t v = 0; v < electric_field.size(); v++)
+    {
+        // iterate over energy values
+        for (size_t i = 0; i < energy_vals.size(); i++)
+        {
+            result = larnest.FullCalculation(
+                NEST::LArInteraction::ER,
+                energy_vals[i],
+                electric_field[v],
+                density,
+                false
+            );
+            output_file << "ER,";
+            output_file << energy_vals[i] << ","; 
+            output_file << electric_field[v] << ",";
+            output_file << result.yields.TotalYield << ",";
+            output_file << result.yields.QuantaYield << ",";
+            output_file << result.yields.LightYield << ",";
+            output_file << result.yields.Nph << ",";
+            output_file << result.yields.Ne << ",";
+            output_file << result.yields.Nex << ",";
+            output_file << result.yields.Nion << "\n";
+        }
+    }
+    output_file.close();
+
+
+    return 0;
+}

--- a/examples/LArNEST/LegacyLArNESTBenchmarks.cpp
+++ b/examples/LArNEST/LegacyLArNESTBenchmarks.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
     // Construct NEST objects for storing calculation results
     NEST::LArYieldResult result;
     std::ofstream output_file;
-    output_file.open("legacy_larnest_benchmarks_" + std::to_string(pdgcode) + ".csv");
+    output_file.open("legacy_benchmarks_" + std::to_string(pdgcode) + ".csv");
     output_file << "energy,efield,TotalYield,QuantaYield,LightYield,Nph,Ne,Nex,Nion\n";
     // iterate over number of events
     for (size_t v = 0; v < electric_field.size(); v++)

--- a/include/NEST/LArNEST.hh
+++ b/include/NEST/LArNEST.hh
@@ -32,6 +32,11 @@ namespace NEST
         Alpha = 2,
     };
 
+    enum class LArFluctuationModel
+    {
+        Default = 0,
+    };
+
     struct LArNRYieldsParameters
     {
         double alpha =  {11.10};
@@ -275,7 +280,8 @@ namespace NEST
          * 
          */
         LArYieldFluctuationResult GetYieldFluctuations(
-            const YieldResult &yields, double density
+            LArFluctuationModel model, const YieldResult &yields, 
+            double density
         );
         /**
          * @brief 
@@ -443,7 +449,17 @@ namespace NEST
         LArYieldResult GetAlphaYields(
             double energy, double efield, double density
         );
-
+        //-------------------------Fluctuation Yields-------------------------//
+        /**
+         * @brief Get the Default Fluctuations object
+         * 
+         * @param yields 
+         * @param density 
+         * @return LArYieldFluctuationResult 
+         */
+        LArYieldFluctuationResult GetDefaultFluctuations(
+            const YieldResult &yields, double density
+        );
         //-------------------------Photon Times-------------------------//
         double GetPhotonTime(
             LArInteraction species, bool exciton,
@@ -526,5 +542,7 @@ namespace NEST
 
         ThomasImelParameters fThomasImelParameters;
         DriftParameters fDriftParameters;
+
+        enum LArFluctuationModel fLArFluctuationModel;
     };
 }

--- a/include/NEST/LArNEST.hh
+++ b/include/NEST/LArNEST.hh
@@ -180,9 +180,6 @@ namespace NEST
 
     struct LArYieldFluctuationResult
     {
-        double TotalYieldFluctuation;
-        double QuantaYieldFluctuation;
-        double LightYieldFluctuation;
         double NphFluctuation;
         double NeFluctuation;
         double NexFluctuation;
@@ -243,15 +240,15 @@ namespace NEST
         void setDriftParameters(DriftParameters driftParameters);
 
         /// get LAr parameters
-        double getDensity() const { return fDensity; }
-        double getRIdealGas() const { return fRIdealGas; }
-        double getRealGasA() const { return fRealGasA; }
-        double getRealGasB() const { return fRealGasB; }
-        double getWorkQuantaFunction() const { return fWorkQuantaFunction; }
-        double getWorkIonFunction() const { return fWorkIonFunction; }
-        double getWorkPhotonFunction() const { return fWorkPhotonFunction; }
-        double getFanoER() const { return fFanoER; }
-        double getNexOverNion() const { return fNexOverNion; }
+        double getDensity()             const { return fDensity; }
+        double getRIdealGas()           const { return fRIdealGas; }
+        double getRealGasA()            const { return fRealGasA; }
+        double getRealGasB()            const { return fRealGasB; }
+        double getWorkQuantaFunction()  const { return fWorkQuantaFunction; }
+        double getWorkIonFunction()     const { return fWorkIonFunction; }
+        double getWorkPhotonFunction()  const { return fWorkPhotonFunction; }
+        double getFanoER()              const { return fFanoER; }
+        double getNexOverNion()         const { return fNexOverNion; }
 
         LArNRYieldsParameters getNRYieldsParameters() { return fNR; }
         LArERYieldsParameters getERYieldsParameters() { return fER; }
@@ -280,7 +277,7 @@ namespace NEST
          * 
          */
         LArYieldFluctuationResult GetYieldFluctuations(
-            LArFluctuationModel model, const YieldResult &yields, 
+            const LArYieldResult &yields, 
             double density
         );
         /**
@@ -458,7 +455,7 @@ namespace NEST
          * @return LArYieldFluctuationResult 
          */
         LArYieldFluctuationResult GetDefaultFluctuations(
-            const YieldResult &yields, double density
+            const LArYieldResult &yields, double density
         );
         //-------------------------Photon Times-------------------------//
         double GetPhotonTime(
@@ -534,6 +531,7 @@ namespace NEST
         double fWorkPhotonFunction = {14.544};
 
         double fNexOverNion = {0.21};
+        double fALF = {1. / (1. + 0.21)};
         double fFanoER = {0.1115};
     
         LArNRYieldsParameters fNR;

--- a/src/LArNEST.cpp
+++ b/src/LArNEST.cpp
@@ -202,6 +202,7 @@ namespace NEST
     //-------------------------Alpha Yields-------------------------//
     double LArNEST::GetAlphaTotalYields(double energy)
     {
+        return 0;
     }  
     double LArNEST::GetAlphaElectronYields(double efield)
     {
@@ -343,7 +344,12 @@ namespace NEST
         {
             cerr << "\nWARNING: TEMPERATURE OUT OF RANGE (84-140 K) for vD\n";
             cerr << "Using value at closest temp for a drift speed estimate\n";
-            Kelvin = (double)NESTcalc::clamp(int(Kelvin), 84, 140);
+            if (Kelvin < 84.) {
+                Kelvin = 84.;
+            }
+            else {
+                Kelvin = 140.;
+            }
         }
         for (size_t i = 0; i < fDriftParameters.A.size() - 1; i++)
         {
@@ -440,7 +446,8 @@ namespace NEST
         return LET;
     }
     std::vector<double> LArNEST::CalculateG2(bool verbosity) 
-    {
+    {   
+        return std::vector<double>();
     }
 
     //------------------------------------Legacy LArNEST------------------------------------//
@@ -584,7 +591,13 @@ namespace NEST
             + DokeBirksC) * (density / legacy_density_LAr);
 
         //check against unphysicality resulting from rounding errors
-        return clamp(recombProb, 0., 1.);
+        if (recombProb < 0.0) {
+            recombProb = 0.0;
+        }
+        if (recombProb > 1.0) {
+            recombProb = 1.0;
+        }
+        return recombProb;
     }
     double LArNEST::LegacyGetLinearEnergyTransfer(double E)
     {

--- a/utils/larnest/lar_dataset.py
+++ b/utils/larnest/lar_dataset.py
@@ -18,10 +18,12 @@ class LArDataset:
         dataset_file:    str='data/lar_data.npz',
         benchmarks_file: str='',
         plot_config:     dict=default_plot_config,
+        fluctuations:    bool=False,
     ):
         self.dataset_file = dataset_file
         self.benchmarks_file = benchmarks_file
         self.plot_config = plot_config
+        self.fluctuations = fluctuations
         # set up datasets
         self.data = dict(np.load(self.dataset_file, allow_pickle=True))
         self.datasets = {key: self.data[key].item() for key in self.data}
@@ -31,7 +33,9 @@ class LArDataset:
             names=[
                 'type','energy', 'efield' , 
                 'TotalYields', 'QuantaYields', 'LightYields', 
-                'Nph' , 'Ne', 'Nex', 'Nion'
+                'Nph' , 'Ne', 'Nex', 'Nion',
+                'TotalYields_std', 'QuantaYields_std', 'LightYields_std',
+                'Nph_std', 'Ne_std', 'Nex_std', 'Nion_std',
             ],
             header=0,
             #dtype=float
@@ -107,11 +111,19 @@ class LArDataset:
             'alpha_nion':   ['Alpha','Nion'],
         }
 
+        self.fluctuation_types = [
+            'Nph', 'Ne', 'Nex', 'Nion'
+        ]
+
         # create plotting directory
         if not os.path.isdir("plots/mean_yields/"):
             os.makedirs("plots/mean_yields")
+        if not os.path.isdir("plots/fluctuations/"):
+            os.makedirs("plots/fluctuations")
         if not os.path.isdir("plots/data/"):
             os.makedirs("plots/data")
+        if not os.path.isdir("plots/data_fluctuations/"):
+            os.makedirs("plots/data_fluctuations")
 
     def plot_data_grid(self,
         dataset_type:   str='nr_total'
@@ -127,7 +139,14 @@ class LArDataset:
             benchmark_mask = (self.benchmarks['type'] == self.benchmark_types[dataset_type][0]) & (self.benchmarks['efield'] == efield)
             energy = self.benchmarks['energy'][benchmark_mask]
             yields = self.benchmarks[self.benchmark_types[dataset_type][1]][benchmark_mask]
+            yields[(yields<0)] = 0
             axs.flat[ii].plot(energy, yields, label=f"NEST - {efield} V/cm")
+            if self.fluctuations:
+                errors = self.benchmarks[self.benchmark_types[dataset_type][1]+"_std"][benchmark_mask]
+                low_errors = yields - errors
+                high_errors = yields + errors
+                low_errors[(low_errors)<0] = 0
+                axs.flat[ii].fill_between(energy, low_errors, high_errors)
             # plot the corresponding data points for this efield
             for jj, dataset in enumerate(self.plot_config[dataset_type][efield]):
                 if (len(self.plot_config[dataset_type][efield][dataset]) < 4):
@@ -169,7 +188,10 @@ class LArDataset:
         fig.supylabel(self.ylabels[dataset_type])
         plt.suptitle(self.titles[dataset_type])
         plt.tight_layout()
-        plt.savefig(f"plots/data/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_Data.png")
+        if self.fluctuations:
+            plt.savefig(f"plots/data_fluctuations/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_Data.png")
+        else:
+            plt.savefig(f"plots/data/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_Data.png")
         plt.close()
 
     def plot_data(self,
@@ -181,7 +203,14 @@ class LArDataset:
             benchmark_mask = (self.benchmarks['type'] == self.benchmark_types[dataset_type][0]) & (self.benchmarks['efield'] == efield)
             energy = self.benchmarks['energy'][benchmark_mask]
             yields = self.benchmarks[self.benchmark_types[dataset_type][1]][benchmark_mask]
+            yields[(yields<0)] = 0
             axs.plot(energy, yields, label=f"NEST - {efield} V/cm")
+            if self.fluctuations:
+                errors = self.benchmarks[self.benchmark_types[dataset_type][1]+"_std"][benchmark_mask]
+                low_errors = yields - errors
+                high_errors = yields + errors
+                low_errors[(low_errors)<0] = 0
+                axs.fill_between(energy, low_errors, high_errors)
             # plot the corresponding data points for this efield
             for jj, dataset in enumerate(self.plot_config[dataset_type][efield]):
                 if (len(self.plot_config[dataset_type][efield][dataset]) < 4):
@@ -223,10 +252,13 @@ class LArDataset:
             axs.set_ylabel(self.ylabels[dataset_type])
             plt.title(self.titles[dataset_type])
             plt.tight_layout()
-            plt.savefig(f"plots/data/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_{efield}_Data.png")
+            if self.fluctuations:
+                plt.savefig(f"plots/data_fluctuations/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_{efield}_Data.png")
+            else:
+                plt.savefig(f"plots/data/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_{efield}_Data.png")
             plt.close()
     
-    def plot_yields(self,
+    def plot_mean_yields(self,
         dataset_type:   str='nr_total'
     ):
         fig, axs = plt.subplots(figsize=(10,6))
@@ -237,6 +269,7 @@ class LArDataset:
             efield_mask = (self.benchmarks['efield'][benchmark_mask] == efield)
             energy = self.benchmarks['energy'][benchmark_mask][efield_mask]
             yields = self.benchmarks[self.benchmark_types[dataset_type][1]][benchmark_mask][efield_mask]
+            yields[(yields<0)] = 0
             axs.plot(energy, yields, label=f"NEST - {efield} V/cm")
         axs.set_xscale("log")
         if ("_n" in dataset_type):
@@ -252,4 +285,38 @@ class LArDataset:
     def plot_all_yields(self,
     ):
         for benchmark_type in self.benchmark_types:
-            self.plot_yields(benchmark_type)
+            self.plot_mean_yields(benchmark_type)
+
+    def plot_fluctuations(self,
+        dataset_type:   str='nr_total'
+    ):
+        # plot the benchmark values for the given efield
+        benchmark_mask = (self.benchmarks['type'] == self.benchmark_types[dataset_type][0])
+        unique_efields = np.unique(self.benchmarks['efield'][benchmark_mask])
+        for efield in unique_efields:
+            fig, axs = plt.subplots(figsize=(10,6))
+            efield_mask = (self.benchmarks['efield'][benchmark_mask] == efield)
+            energy = self.benchmarks['energy'][benchmark_mask][efield_mask]
+            yields = self.benchmarks[self.benchmark_types[dataset_type][1]][benchmark_mask][efield_mask]
+            yields[(yields<0)] = 0
+            errors = self.benchmarks[self.benchmark_types[dataset_type][1]+"_std"][benchmark_mask][efield_mask]
+            low_errors = yields - errors
+            high_errors = yields + errors
+            low_errors[(low_errors)<0] = 0
+            axs.fill_between(energy, low_errors, high_errors, color='y', alpha=0.7)
+            axs.plot(energy, yields, label=f"NEST - {efield} V/cm", color='k', linestyle='-')
+            axs.set_xscale("log")
+            if ("_n" in dataset_type):
+                axs.set_yscale("log")
+            plt.legend(bbox_to_anchor=(1.05, 1.0), loc='upper left')
+            axs.set_xlabel("Energy [keV]")
+            axs.set_ylabel(self.ylabels[dataset_type])
+            plt.title(self.titles[dataset_type])
+            plt.tight_layout()
+            plt.savefig(f"plots/fluctuations/{self.benchmark_types[dataset_type][0]}_{self.benchmark_types[dataset_type][1]}_{efield}Vcm.png")
+            plt.close()
+    
+    def plot_all_fluctuations(self,
+    ):
+        for benchmark_type in self.benchmark_types:
+            self.plot_fluctuations(benchmark_type)

--- a/utils/larnest/lar_dataset.py
+++ b/utils/larnest/lar_dataset.py
@@ -15,10 +15,10 @@ class LArDataset:
     """
     """
     def __init__(self,
-        dataset_file:    str='data/lar_data.npz',
-        benchmarks_file: str='',
-        plot_config:     dict=default_plot_config,
-        fluctuations:    bool=False,
+        dataset_file:   str='data/lar_data.npz',
+        benchmarks_file:str='',
+        plot_config:    dict=default_plot_config,
+        fluctuations:   bool=False,
     ):
         self.dataset_file = dataset_file
         self.benchmarks_file = benchmarks_file

--- a/utils/larnest/lar_dataset.py
+++ b/utils/larnest/lar_dataset.py
@@ -15,10 +15,10 @@ class LArDataset:
     """
     """
     def __init__(self,
-        dataset_file:   str='data/lar_data.npz',
-        benchmarks_file:str='',
-        plot_config:    dict=default_plot_config,
-        fluctuations:   bool=False,
+        dataset_file: str='data/lar_data.npz',
+        benchmarks_file: str='',
+        plot_config: dict=default_plot_config,
+        fluctuations: bool=False,
     ):
         self.dataset_file = dataset_file
         self.benchmarks_file = benchmarks_file
@@ -288,7 +288,7 @@ class LArDataset:
             self.plot_mean_yields(benchmark_type)
 
     def plot_fluctuations(self,
-        dataset_type:   str='nr_total'
+        dataset_type: str='nr_total'
     ):
         # plot the benchmark values for the given efield
         benchmark_mask = (self.benchmarks['type'] == self.benchmark_types[dataset_type][0])

--- a/utils/larnest/plot_benchmarks.py
+++ b/utils/larnest/plot_benchmarks.py
@@ -12,29 +12,40 @@ from lar_dataset import LArDataset
 if __name__ == "__main__":
 
     dataset_file = "data/lar_data.npz"
-    benchmarks_file = "data/benchmarks.csv"
-    
+    mean_yields_benchmarks_file = "data/mean_yields_benchmarks.csv"
+    fluctuations_benchmarks_file = "data/fluctuation_benchmarks.csv"
+    lar_datasets = []
+
     # create the dataset object
-    lar_dataset = LArDataset(
+    lar_datasets.append(LArDataset(
         dataset_file=dataset_file,
-        benchmarks_file=benchmarks_file,
+        benchmarks_file=mean_yields_benchmarks_file,
         plot_config=default_plot_config,
-    )
+        fluctuations=False,
+    ))
+    lar_datasets.append(LArDataset(
+        dataset_file=dataset_file,
+        benchmarks_file=fluctuations_benchmarks_file,
+        plot_config=default_plot_config,
+        fluctuations=True,
+    ))
 
     # make benchmark plots
-    lar_dataset.plot_all_yields()
+    lar_datasets[0].plot_all_yields()
+    lar_datasets[1].plot_all_fluctuations()
 
-    # plot with data
-    # nr yields
-    lar_dataset.plot_data('nr_total')
-    lar_dataset.plot_data_grid('nr_total')
-    lar_dataset.plot_data('nr_charge')
-    lar_dataset.plot_data_grid('nr_charge')
-    lar_dataset.plot_data('nr_light')
-    lar_dataset.plot_data_grid('nr_light')
+    for ii, lar_dataset in enumerate(lar_datasets):
+        # plot with data
+        # nr yields
+        lar_dataset.plot_data('nr_total')
+        lar_dataset.plot_data_grid('nr_total')
+        lar_dataset.plot_data('nr_charge')
+        lar_dataset.plot_data_grid('nr_charge')
+        lar_dataset.plot_data('nr_light')
+        lar_dataset.plot_data_grid('nr_light')
 
-    # er yields
-    lar_dataset.plot_data('er_charge')
-    lar_dataset.plot_data_grid('er_charge')
-    lar_dataset.plot_data('er_light')
-    lar_dataset.plot_data_grid('er_light')
+        # er yields
+        lar_dataset.plot_data('er_charge')
+        lar_dataset.plot_data_grid('er_charge')
+        lar_dataset.plot_data('er_light')
+        lar_dataset.plot_data_grid('er_light')

--- a/utils/larnest/utils.py
+++ b/utils/larnest/utils.py
@@ -26,8 +26,9 @@ def generate_plot_grid(
         axs.flat[-(ii+1)].set_visible(False)
     return fig, axs
 
-if __name__ == "__main__":
-
+def compile_lar_data(
+    data_dir:   str="data/",
+):
     nr_total = {
         "Dataset":  [],
         "energy":   [],
@@ -40,7 +41,7 @@ if __name__ == "__main__":
         "yield_sl": [],
         "yield_sh": []
     }
-    with open("data/nr_total_alt.csv","r") as file:
+    with open(f"{data_dir}nr_total_alt.csv","r") as file:
         reader = csv.reader(file, delimiter=",")
         next(reader)
         for row in reader:
@@ -67,7 +68,7 @@ if __name__ == "__main__":
         "yield_sl": [],
         "yield_sh": []
     }
-    with open("data/nr_charge_alt.csv","r") as file:
+    with open(f"{data_dir}nr_charge_alt.csv","r") as file:
         reader = csv.reader(file, delimiter=",")
         next(reader)
         for row in reader:
@@ -94,7 +95,7 @@ if __name__ == "__main__":
         "yield_sl": [],
         "yield_sh": []
     }
-    with open("data/nr_light_alt.csv","r") as file:
+    with open(f"{data_dir}nr_light_alt.csv","r") as file:
         reader = csv.reader(file, delimiter=",")
         next(reader)
         for row in reader:
@@ -121,7 +122,7 @@ if __name__ == "__main__":
         "yield_sl": [],
         "yield_sh": []
     }
-    with open("data/er_charge.csv","r") as file:
+    with open(f"{data_dir}er_charge.csv","r") as file:
         reader = csv.reader(file, delimiter=",")
         next(reader)
         for row in reader:
@@ -148,7 +149,7 @@ if __name__ == "__main__":
         "yield_sl": [],
         "yield_sh": []
     }
-    with open("data/er_light.csv","r") as file:
+    with open(f"{data_dir}er_light.csv","r") as file:
         reader = csv.reader(file, delimiter=",")
         next(reader)
         for row in reader:
@@ -165,10 +166,14 @@ if __name__ == "__main__":
     er_light = {key: np.array(er_light[key]) for key in er_light}
     
     np.savez(
-        "data/lar_data.npz",
+        f"{data_dir}lar_data.npz",
         nr_total=nr_total,
         nr_charge=nr_charge,
         nr_light=nr_light,
         er_charge=er_charge,
         er_light=er_light,
     )
+
+if __name__ == "__main__":
+
+    compile_lar_data()

--- a/utils/larnest/utils.py
+++ b/utils/larnest/utils.py
@@ -26,8 +26,8 @@ def generate_plot_grid(
         axs.flat[-(ii+1)].set_visible(False)
     return fig, axs
 
-def compile_lar_data(
-    data_dir:   str="data/",
+def compile_nr_total_data(
+    data_dir: str="data/",
 ):
     nr_total = {
         "Dataset":  [],
@@ -55,7 +55,11 @@ def compile_lar_data(
             nr_total["yield"].append(float(row[7]))
             nr_total["yield_sl"].append(float(row[8]))
             nr_total["yield_sh"].append(float(row[9]))
-    nr_total = {key: np.array(nr_total[key]) for key in nr_total}
+    return {key: np.array(nr_total[key]) for key in nr_total}
+
+def compile_nr_charge_data(
+    data_dir: str="data/",
+):
     nr_charge = {
         "Dataset":  [],
         "energy":   [],
@@ -82,7 +86,11 @@ def compile_lar_data(
             nr_charge["yield"].append(float(row[7]))
             nr_charge["yield_sl"].append(float(row[8]))
             nr_charge["yield_sh"].append(float(row[9]))
-    nr_charge = {key: np.array(nr_charge[key]) for key in nr_charge}
+    return {key: np.array(nr_charge[key]) for key in nr_charge}
+
+def compile_nr_light_data(
+    data_dir: str="data/",
+):
     nr_light = {
         "Dataset":  [],
         "energy":   [],
@@ -109,7 +117,11 @@ def compile_lar_data(
             nr_light["yield"].append(float(row[7]))
             nr_light["yield_sl"].append(float(row[8]))
             nr_light["yield_sh"].append(float(row[9]))
-    nr_light = {key: np.array(nr_light[key]) for key in nr_light}
+    return {key: np.array(nr_light[key]) for key in nr_light}
+
+def compile_er_charge_data(
+    data_dir: str="data/",
+):
     er_charge = {
         "Dataset":  [],
         "energy":   [],
@@ -136,7 +148,11 @@ def compile_lar_data(
             er_charge["yield"].append(float(row[7]))
             er_charge["yield_sl"].append(float(row[8]))
             er_charge["yield_sh"].append(float(row[9]))
-    er_charge = {key: np.array(er_charge[key]) for key in er_charge}
+    return {key: np.array(er_charge[key]) for key in er_charge}
+
+def compile_er_light_data(
+    data_dir: str="data/",
+):
     er_light = {
         "Dataset":  [],
         "energy":   [],
@@ -163,15 +179,18 @@ def compile_lar_data(
             er_light["yield"].append(float(row[7]))
             er_light["yield_sl"].append(float(row[8]))
             er_light["yield_sh"].append(float(row[9]))
-    er_light = {key: np.array(er_light[key]) for key in er_light}
+    return {key: np.array(er_light[key]) for key in er_light}
     
+def compile_lar_data(
+    data_dir: str="data/",
+):
     np.savez(
         f"{data_dir}lar_data.npz",
-        nr_total=nr_total,
-        nr_charge=nr_charge,
-        nr_light=nr_light,
-        er_charge=er_charge,
-        er_light=er_light,
+        nr_total=compile_nr_total_data(data_dir),
+        nr_charge=compile_nr_charge_data(data_dir),
+        nr_light=compile_nr_light_data(data_dir),
+        er_charge=compile_er_charge_data(data_dir),
+        er_light=compile_er_light_data(data_dir),
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added default binomial fluctuations model to LArNEST with adjustable parameters.  These fluctuations mimic the standard LXe NEST, but without omega/skewness factors.  Also added a script in the examples/LArNEST folder for generating fluctuation statistics for NR/ER/Alpha interactions, as well as python scripts for plotting the results.