### PR TITLE
bugfix for the g4 integration. 

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -210,6 +210,7 @@ void NESTProc::TryPopLineages(const G4Track& aTrack, const G4Step& aStep) {
 
 G4VParticleChange* NESTProc::AtRestDoIt(const G4Track& aTrack,
                                         const G4Step& aStep) {
+  PostStepDoIt(aTrack, aStep);
   pParticleChange->Initialize(aTrack);
   return G4VRestDiscreteProcess::AtRestDoIt(aTrack, aStep);
 }


### PR DESCRIPTION
Ion decays from primaries with zero kinetic energy were not triggering the creation of lineages. Diagnosed with the help of Eric Church and Krishan Mistry