### PR TITLE
Replaced undefined `uint` with standard type `unsigned int`

### DIFF
--- a/G4integration/NESTProc.cpp
+++ b/G4integration/NESTProc.cpp
@@ -268,7 +268,7 @@ G4VParticleChange* NESTProc::PostStepDoIt(const G4Track& aTrack,
   // Type of this step.
   INTERACTION_TYPE step_type = NoneType;
 
-  uint sec_mylinid = 0;
+  unsigned int sec_mylinid = 0;
 
   const vector<const G4Track*> secondaries = *aStep.GetSecondaryInCurrentStep();
 

--- a/src/execNEST.cpp
+++ b/src/execNEST.cpp
@@ -32,7 +32,7 @@ vector<double> NRERWidthsParam, NRYieldsParam, ERWeightParam,
 double band[NUMBINS_MAX][7], energies[3],
     AnnModERange[2] = {1.5, 6.5};  // keVee or nr (recon)
 bool BeenHere = false;
-uint SaveTheDates[tMax] = {0};
+unsigned int SaveTheDates[tMax] = {0};
 bool dEOdxBasis = false;
 double minTimeSeparation = 0.;  // ns (Kr83m)
 
@@ -1311,7 +1311,7 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
   }  // end of the gigantic primary event number loop
 
   if (timeStamp > tZero) {
-    for (uint j = 0; j < tMax; ++j) {
+    for (unsigned int j = 0; j < tMax; ++j) {
       cerr << j << "\t" << SaveTheDates[j] << endl;
     }
   }


### PR DESCRIPTION
On both Alma Linux 9.3 and a recent version of Void Linux musl, NEST fails to compile, in particular citing

```
/home/<user>/src/nest/src/execNEST.cpp:35:1: error: 'uint' does not name a type; did you mean 'int'?
   35 | uint SaveTheDates[tMax] = {0};
      | ^~~~
      | int
```
which seems to be caused by the codebase implicitly assuming a type `uint` exists. To my knowledge `uint` is not a standard type and is only implemented as a typedef for `unsigned int` by some compilers. With this change, NEST successfully compiles on the above-mentioned systems. 