### PR TITLE
Added extra optons to runNESTvec and updated NESTObservableArray to simplify function 

### DIFF
--- a/include/NEST/execNEST.hh
+++ b/include/NEST/execNEST.hh
@@ -1,27 +1,37 @@
 #ifndef __EXECNEST_H__
 #define __EXECNEST_H__ 1
 
+#include "NEST.hh"
+
 using namespace std;
 using namespace NEST;
 
-struct NESTObservableArray {
-  vector<int> s1_nhits;
-  vector<int> s1_nhits_thr;
-  vector<int> s1_nhits_dpe;
-  vector<double> s1r_phe;
-  vector<double> s1c_phe;
-  vector<double> s1r_phd;
-  vector<double> s1c_phd;
-  vector<double> s1r_spike;
-  vector<double> s1c_spike;
-  vector<int> Nee;
-  vector<int> Nph;
-  vector<int> s2_nhits;
-  vector<int> s2_nhits_dpe;
-  vector<double> s2r_phe;
-  vector<double> s2c_phe;
-  vector<double> s2r_phd;
-  vector<double> s2c_phd;
+
+class NESTObservableArray {
+  public:
+    NESTObservableArray(){};
+    ~NESTObservableArray() = default;
+
+    void store_signals(std::vector<double> s1, std::vector<double> s2);
+
+    std::vector<int> s1_nhits;
+    std::vector<int> s1_nhits_thr;
+    std::vector<int> s1_nhits_dpe;
+    std::vector<double> s1r_phe;
+    std::vector<double> s1c_phe;
+    std::vector<double> s1r_phd;
+    std::vector<double> s1c_phd;
+    std::vector<double> s1r_spike;
+    std::vector<double> s1c_spike;
+    std::vector<int> Nee;
+    std::vector<int> Nph;
+    std::vector<int> s2_nhits;
+    std::vector<int> s2_nhits_dpe;
+    std::vector<double> s2r_phe;
+    std::vector<double> s2c_phe;
+    std::vector<double> s2r_phd;
+    std::vector<double> s2c_phd;
+
 };
 
 vector<vector<double>> GetBand(vector<double> S1s, vector<double> S2s,
@@ -33,10 +43,16 @@ int execNEST(VDetector* detector, double numEvts, const string& type,
              double eMin, double eMax, double inField, string position,
              const string& posiMuon, double fPos, int seed, bool no_seed,
              double dayNumber);
+
 NESTObservableArray runNESTvec(VDetector* detector,
                                INTERACTION_TYPE scatterType,
                                std::vector<double> eList,
                                std::vector<std::vector<double>> pos3dxyz,
-                               double inField = -1.0, int seed = 0);
+                               double inField = -1.0, int seed = 0,   
+                               std::vector<double> ERYieldsParam = default_ERYieldsParam,
+                               std::vector<double> NRYieldsParam = default_NRYieldsParam,
+                               std::vector<double> NRERWidthsParam = default_NRERWidthsParam,
+                               S1CalculationMode s1mode = NEST::S1CalculationMode::Full,
+                               S2CalculationMode s2mode = NEST::S2CalculationMode::Full);
 
 #endif


### PR DESCRIPTION
This PR allows the user to pass additional options to the `runNESTvec`.  Specifically, this function now has 
```
NESTObservableArray runNESTvec(VDetector* detector,
                               INTERACTION_TYPE scatterType,
                               std::vector<double> eList,
                               std::vector<std::vector<double>> pos3dxyz,
                               double inField = -1.0, int seed = 0,   
                               std::vector<double> ERYieldsParam = default_ERYieldsParam,
                               std::vector<double> NRYieldsParam = default_NRYieldsParam,
                               std::vector<double> NRERWidthsParam = default_NRERWidthsParam,
                               S1CalculationMode s1mode = NEST::S1CalculationMode::Full,
                               S2CalculationMode s2mode = NEST::S2CalculationMode::Full);
```
Allowing the user to change the yield parameters and the S1 and S2 calculation modes.  

In doing this update, which I was partially using to help people understand how to run NEST, I also converted `NESTObservableArray` to be a class with a 
```
void NESTObservableArray::store_signals(std::vector<double> s1, std::vector<double> s2)
```
method to make the functionary NEST code the main component of `runNESTvec` which should hopefully making this function a little easier to follow for people with less experience using NEST.

As these were changes I made for my specific usecase I appreciate that there might be changes that I have implemented which it be best to remove