### PR TITLE
Changed standard halo model velocity distribution to a truncated Maxwell-Boltzmann distritbuion

### DIFF
--- a/src/TestSpectra.cpp
+++ b/src/TestSpectra.cpp
@@ -300,7 +300,9 @@ double TestSpectra::WIMP_dRate(double ER, double mWimp, double dayNum) {
   if (ER != 0.) {
     v_min = c * (((M_T * ER) / mu_TD) + delta) / (root2 * sqrt(M_T * ER));
   }
-  double bet = 1.;
+  double bet = 0.; //this controls whether the velocity distribution is
+  // a trunctated maxwell-boltzmann distribution or a shifted
+  // maxwell-boltzmann distribution. 0 for truncated, 1 for shifted.
 
   // Start calculating the differential rate for this energy bin, starting
   // with the velocity integral:


### PR DESCRIPTION
Set beta to 0 in WIMP_dRate - equivalent to changing the WIMP velocity distribution from a shifted maxwell-boltzmann distribution to a truncated maxwell-boltzmann distribution. 