### PR TITLE
Add energy-dependent NR charge-yield suppression

### DIFF
--- a/src/NEST.cpp
+++ b/src/NEST.cpp
@@ -802,10 +802,25 @@ YieldResult NESTcalc::GetYieldNR(double energy, double density, double dfield,
   if (!fdetector->get_OldW13eV() && ValidityTests::nearlyEqual(ATOM_NUM, 54.)) Nq *= ZurichEXOW;
   double ThomasImel = NRYieldsParam[2] * pow(dfield, NRYieldsParam[3]) *
                       pow(density / DENSITY, 0.3);
+                      
+  double p = NRYieldsParam[9];  
+  if (NRYieldsParam.size() >= 15) {
+    const double a = NRYieldsParam[12];
+    const double b = NRYieldsParam[13];
+    const double E0 = NRYieldsParam[14];
+
+    if (energy > E0) {
+      p = 0.5 + a * log(1. + b * (energy - E0));
+    } else {
+      p = 0.5;
+    }
+  }
   double Qy =
-      1. / (ThomasImel * pow(energy + NRYieldsParam[4], NRYieldsParam[9]));
+      1. / (ThomasImel * pow(energy + NRYieldsParam[4], p));
+
   Qy *= 1. - 1. / pow(1. + pow((energy / NRYieldsParam[5]), NRYieldsParam[6]),
                       NRYieldsParam[10]);
+                      
   if (!fdetector->get_OldW13eV()) Qy *= ZurichEXOQ;
   double Ly = Nq / energy - Qy;
   if (Qy < 0.0) Qy = 0.0;


### PR DESCRIPTION
Adds an optional energy-dependent modification to the NR charge-yield in power law form.
If the standard 12-parameter yield, the behavior is not changed.
When 15 yield parameters are provided, the final three will be used as a, b, and E0, with
p(E) = 0.5, E <= E0
p(E) = 0.5 + a * ln[1 + b*(E-E0)], E > E0